### PR TITLE
Refactor OIF args

### DIFF
--- a/dispatch.c
+++ b/dispatch.c
@@ -53,7 +53,7 @@ BackendHandle load_backend_python(
         size_t version_minor
 ) {
     // Start Python interpreter here.
-    fprintf(stderr, "This is not yet implemented correctly");
+    fprintf(stderr, "[dispatch] This is not yet implemented correctly");
     exit(EXIT_FAILURE);
     return BACKEND_PYTHON;
 }
@@ -85,12 +85,12 @@ int
 run_interface_method_c(const char *method, OIFArgs *args, OIFArgs *out_args) {
     void *lib_handle = dlopen(OIF_BACKEND_C_SO, RTLD_LOCAL | RTLD_LAZY); 
     if (lib_handle == NULL) {
-        fprintf(stderr, "Cannot load shared library %s\n", OIF_BACKEND_C_SO);
+        fprintf(stderr, "[dispatch] Cannot load shared library %s\n", OIF_BACKEND_C_SO);
         exit(EXIT_FAILURE);
     }
     void *func = dlsym(lib_handle, method);
     if (func == NULL) {
-        fprintf(stderr, "Cannot load interface '%s'\n", method);
+        fprintf(stderr, "[dispatch] Cannot load interface '%s'\n", method);
         exit(EXIT_FAILURE);
     }
 
@@ -112,7 +112,7 @@ run_interface_method_c(const char *method, OIFArgs *args, OIFArgs *out_args) {
             arg_types[i] = &ffi_type_double;
         } else {
             fflush(stdout);
-            fprintf(stderr, "Unknown arg type: %d", args->arg_types[i]);
+            fprintf(stderr, "[dispatch] Unknown arg type: %d", args->arg_types[i]);
             fflush(stderr);
             exit(EXIT_FAILURE);
         }

--- a/dispatch.h
+++ b/dispatch.h
@@ -20,7 +20,7 @@ typedef enum {
 typedef struct {
     size_t num_args;
     OIFArgType *arg_types;
-    void **args;
+    void **arg_values;
 } OIFArgs;
 
 
@@ -57,7 +57,7 @@ int call_interface_method(
 );
 
 
-int run_interface_method_c(const char *method, OIFArgs *args, OIFArgs *retvals);
+int run_interface_method_c(const char *method, OIFArgs *in_args, OIFArgs *out_args);
 
 
-int run_interface_method_python(const char *method, OIFArgs *args, OIFArgs *retvals);
+int run_interface_method_python(const char *method, OIFArgs *in_args, OIFArgs *out_args);

--- a/dispatch.h
+++ b/dispatch.h
@@ -8,10 +8,10 @@ typedef size_t BackendHandle;
 
 
 typedef enum {
-    OIF_INT,
-    OIF_FLOAT32,
-    OIF_FLOAT64,
-    OIF_STR,
+    OIF_INT = 1,
+    OIF_FLOAT32 = 2,
+    OIF_FLOAT64 = 3,
+    OIF_STR = 4,
 } OIFArgType;
 
 

--- a/dispatch.h
+++ b/dispatch.h
@@ -11,7 +11,9 @@ typedef enum {
     OIF_INT = 1,
     OIF_FLOAT32 = 2,
     OIF_FLOAT64 = 3,
-    OIF_STR = 4,
+    OIF_FLOAT32_P = 4,
+    OIF_FLOAT64_P = 5,
+    OIF_STR = 6,
 } OIFArgType;
 
 

--- a/src/oif/core.py
+++ b/src/oif/core.py
@@ -7,6 +7,7 @@ UInt = NewType("UInt", int)
 OIF_INT = 1
 OIF_FLOAT32 = 2
 OIF_FLOAT64 = 3
+OIF_STR = 4
 
 
 class OIFArgType(ctypes.c_int):

--- a/src/oif/qeq_solver.py
+++ b/src/oif/qeq_solver.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from oif.core import OIFBackend, init_backend
 
 
@@ -6,5 +8,5 @@ class QeqSolver:
         self.backend: OIFBackend = init_backend(provider, "qeq", 1, 0)
 
     def solve(self, a: float, b: float, c: float):
-        res = self.backend.call("solve_qeq", (a, b, c), [])
+        res = self.backend.call("solve_qeq", (a, b, c), (np.empty(2),))
         return res


### PR DESCRIPTION
Refactor OIFArgs structure and dispatch library

- OIFArgs struct had the `args` member that is renamed to `arg_values`
for clarity
- In interface invokation functions, `args` and `retvals` are renamed
  to `in_args` and `out_args`
