### PR TITLE
Enable passing arrays in Python -> C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.18)
 
 project(oif-toy-example LANGUAGES C CXX)
 
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message("Disable optimizations for Debug build type")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0")
+endif()
+
 add_library(oif_dispatch SHARED dispatch.c)
 target_include_directories(oif_dispatch PUBLIC .)
 target_link_libraries(oif_dispatch PUBLIC ffi)

--- a/src/oif/core.py
+++ b/src/oif/core.py
@@ -1,13 +1,17 @@
 import ctypes
 from typing import NewType
 
+import numpy as np
+
 UInt = NewType("UInt", int)
 
 
 OIF_INT = 1
 OIF_FLOAT32 = 2
 OIF_FLOAT64 = 3
-OIF_STR = 4
+OIF_FLOAT32_P = 4
+OIF_FLOAT64_P = 5
+OIF_STR = 6
 
 
 class OIFArgType(ctypes.c_int):
@@ -42,6 +46,10 @@ class OIFBackend:
                 arg_void_p = ctypes.cast(arg_p, ctypes.c_void_p)
                 arg_values.append(arg_void_p)
                 arg_types.append(OIF_FLOAT64)
+            elif isinstance(arg, np.ndarray):
+                print("Warning: we assume that dtype is np.float64")
+                arg_values.append(arg.data.as_type(ctypes.c_double_p))
+                arg_types.append(OIF_FLOAT64_P)
             else:
                 raise ValueError("Cannot handle argument type")
 
@@ -66,6 +74,10 @@ class OIFBackend:
                 arg_void_p = ctypes.cast(arg_p, ctypes.c_void_p)
                 out_arg_values.append(arg_void_p)
                 out_arg_types.append(OIF_FLOAT64)
+            elif isinstance(arg, np.ndarray):
+                print("Warning: we assume that dtype is np.float64")
+                out_arg_values.append(arg.ctypes.data_as(ctypes.c_void_p))
+                out_arg_types.append(OIF_FLOAT64_P)
             else:
                 raise ValueError("Cannot handle argument type")
 

--- a/src/oif/qeq_solver.py
+++ b/src/oif/qeq_solver.py
@@ -8,5 +8,5 @@ class QeqSolver:
         self.backend: OIFBackend = init_backend(provider, "qeq", 1, 0)
 
     def solve(self, a: float, b: float, c: float):
-        res = self.backend.call("solve_qeq", (a, b, c), (np.empty(2),))
+        res = self.backend.call("solve_qeq", (a, b, c), (np.array([11.0, 22.0]),))
         return res


### PR DESCRIPTION
This PR enables passing array arguments from user Python code to C implementors.
Also, I have fixed bugs in the implementation of C backend and improved the logging messages.