### PR TITLE
Polish example of quadratic solver Python -> C

### DIFF
--- a/dispatch.c
+++ b/dispatch.c
@@ -104,7 +104,6 @@ run_interface_method_c(const char *method, OIFArgs *in_args, OIFArgs *out_args) 
 
     // Merge input and output argument types together in `arg_types` array.
     for (size_t i = 0; i < num_in_args; ++i) {
-        printf("Processing in_args[%zu] = %u\n", i, in_args->arg_types[i]);
         if (in_args->arg_types[i] == OIF_FLOAT64) {
             arg_types[i] = &ffi_type_double;
         } else if (in_args->arg_types[i] == OIF_FLOAT64_P) {
@@ -150,23 +149,6 @@ run_interface_method_c(const char *method, OIFArgs *in_args, OIFArgs *out_args) 
             arg_values[i] = &out_args->arg_values[i - num_in_args];
         } else {
             arg_values[i] = out_args->arg_values[i - num_in_args];
-        }
-    }
-
-    for (size_t i = 0; i < num_total_args; ++i) {
-        printf("Pointer arg_values[%zu] = %p, with value", i, arg_values[i]);
-        if (arg_types[i] == &ffi_type_double) {
-            printf(" = %f\n", *((double *) arg_values[i]));
-        } else if (arg_types[i] == &ffi_type_pointer) {
-            printf("s [0] = %f, [1] = %f\n",
-                    ((double *) arg_values[i])[0],
-                    ((double *) arg_values[i])[1]);
-        }
-
-        if (arg_types[i] == &ffi_type_pointer) {
-            if (arg_values[i] == NULL) {
-                fprintf(stderr, "[backend_c] Output argument has a null pointer\n");
-            }
         }
     }
 

--- a/examples/qeq_from_c.py
+++ b/examples/qeq_from_c.py
@@ -3,7 +3,7 @@ from oif.qeq_solver import QeqSolver
 
 def main():
     s = QeqSolver("c")
-    a, b, c = 1.0, 2.0, 1.0
+    a, b, c = 1.0, 5.0, 4.0
     x = s.solve(a, b, c)
 
     print(f"Solving quadratic equation for a = {a}, b = {b}, c = {c}")

--- a/src/oif/backend_c/qeq.c
+++ b/src/oif/backend_c/qeq.c
@@ -2,16 +2,23 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+
+/**
+ * Solve quadratic equation ax**2 + bx + c = 0
+ * Assumes that the output array `roots` always has two elements,
+ * so if the roots are repeated, they both will be still present.
+ * @param a Coefficient before x**2
+ * @param b Coefficient before x
+ * @param c Free term
+ * @param roots Array with two elements to which the found roots are written.
+ * @return int
+ */
 int solve_qeq(double a, double b, double c, double *roots)
 {
-    printf("I am in solve_qeq\n");
     if (roots == NULL) {
         fprintf(stderr, "Memory for the roots array was not provided\n");
         exit(EXIT_FAILURE);
-    } else {
-        fprintf(stderr, "root is memory\n");
     }
-    fflush(stdout);
     if (a == 0.0) {
         roots[0] = -c / b;
         roots[1] = -c / b;

--- a/src/oif/core.py
+++ b/src/oif/core.py
@@ -81,8 +81,6 @@ class OIFBackend:
             else:
                 raise ValueError("Cannot handle argument type")
 
-        print("out_arg_types = ", out_arg_types)
-
         out_arg_types_ctypes = ctypes.cast(
             (ctypes.c_int * len(out_arg_types))(*out_arg_types),
             ctypes.POINTER(OIFArgType),
@@ -111,7 +109,13 @@ class OIFBackend:
             ctypes.byref(out_packed),
         )
 
-        return 42
+        # result = []
+        # print("Output arguments after call_interface_method")
+        # for typ, val in zip(out_arg_types, out_arg_values):
+        #     if typ == OIF_FLOAT64_P:
+        #         result.append(out_arg_values)
+
+        return 0
 
 
 def init_backend(backend: str, interface: str, major: UInt, minor: UInt):

--- a/src/oif/qeq_solver.py
+++ b/src/oif/qeq_solver.py
@@ -8,5 +8,6 @@ class QeqSolver:
         self.backend: OIFBackend = init_backend(provider, "qeq", 1, 0)
 
     def solve(self, a: float, b: float, c: float):
-        res = self.backend.call("solve_qeq", (a, b, c), (np.array([11.0, 22.0]),))
-        return res
+        result = np.array([11.0, 22.0])
+        self.backend.call("solve_qeq", (a, b, c), (result,))
+        return result


### PR DESCRIPTION
Now, with only one example of implementation, where the only output argument is an `ndarray`, it is difficult to say what extra job Python adapter needs to do to convert between Python and C.

Right now, with an `ndarray`, nothing should be done, as the array is modified in place and can be returned to the user as is.

Additionally, I removed all redundant output that is not useful for users.