### PR TITLE
Move logic of obtaining pointer to ndarray to OIFBackend in Python

### DIFF
--- a/dispatch.c
+++ b/dispatch.c
@@ -138,18 +138,10 @@ run_interface_method_c(const char *method, OIFArgs *in_args, OIFArgs *out_args) 
 
     // Merge input and output argument values together in `arg_values` array.
     for (size_t i = 0; i < num_in_args; ++i) {
-        if (in_args->arg_types[i] == OIF_FLOAT64_P) {
-            arg_values[i] = &in_args->arg_values[i];
-        } else {
-            arg_values[i] = in_args->arg_values[i];
-        }
+        arg_values[i] = in_args->arg_values[i];
     }
     for (size_t i = num_in_args; i < num_total_args; ++i) {
-        if (out_args->arg_types[i - num_in_args] == OIF_FLOAT64_P) {
-            arg_values[i] = &out_args->arg_values[i - num_in_args];
-        } else {
-            arg_values[i] = out_args->arg_values[i - num_in_args];
-        }
+        arg_values[i] = out_args->arg_values[i - num_in_args];
     }
 
     unsigned result;

--- a/src/oif/core.py
+++ b/src/oif/core.py
@@ -48,7 +48,9 @@ class OIFBackend:
                 arg_types.append(OIF_FLOAT64)
             elif isinstance(arg, np.ndarray):
                 print("Warning: we assume that dtype is np.float64")
-                arg_values.append(arg.data.as_type(ctypes.c_double_p))
+                arg_p = ctypes.pointer(arg.data.as_type(ctypes.c_void_p))
+                arg_p_void = ctypes.cast(arg_p, ctypes.c_void_p)
+                arg_values.append(arg_p_void)
                 arg_types.append(OIF_FLOAT64_P)
             else:
                 raise ValueError("Cannot handle argument type")
@@ -76,7 +78,9 @@ class OIFBackend:
                 out_arg_types.append(OIF_FLOAT64)
             elif isinstance(arg, np.ndarray):
                 print("Warning: we assume that dtype is np.float64")
-                out_arg_values.append(arg.ctypes.data_as(ctypes.c_void_p))
+                arg_p = ctypes.pointer(arg.ctypes.data_as(ctypes.c_void_p))
+                arg_void_p = ctypes.cast(arg_p, ctypes.c_void_p)
+                out_arg_values.append(arg_void_p)
                 out_arg_types.append(OIF_FLOAT64_P)
             else:
                 raise ValueError("Cannot handle argument type")


### PR DESCRIPTION
I refactored the code with the help from Stephan Rave, who noticed that I can obtain a pointer to ndarray directly in Python instead of using `&` operator in C backend.

It is better if all logic of obtaining pointers to variables is concentrated in one place, than when it is scattered between different components.