### PR TITLE
Pass arrays between frontend and backend as OIFArray

### DIFF
--- a/dispatch.c
+++ b/dispatch.c
@@ -58,6 +58,14 @@ int call_interface_method(
         fprintf(stderr, "[dispatch] Cannot call interface on backend handle: '%zu'", bh);
         exit(EXIT_FAILURE);
     }
+
+    if (status) {
+        fprintf(
+            stderr,
+            "[dispatch] ERROR: during execution of open interface "
+            "an error occurred\n"
+        );
+    }
     return status;
 }
 

--- a/dispatch.h
+++ b/dispatch.h
@@ -2,7 +2,6 @@
 #include <stdlib.h>
 
 
-
 // Identifier of the used backend.
 typedef size_t BackendHandle;
 
@@ -22,6 +21,16 @@ typedef struct {
     OIFArgType *arg_types;
     void **arg_values;
 } OIFArgs;
+
+// This structure closely follows PyArray_Object that describes NumPy arrays.
+typedef struct {
+    // Number of dimensions in the array.
+    int nd;
+    // Size of each axis, i = 0, .., nd-1.
+    int *dimensions;
+    // Pointer to actual data.
+    char *data;
+} OIFArray;
 
 enum
 {

--- a/dispatch.h
+++ b/dispatch.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <stdint.h>
 #include <stdlib.h>
 
 
@@ -27,7 +28,7 @@ typedef struct {
     // Number of dimensions in the array.
     int nd;
     // Size of each axis, i = 0, .., nd-1.
-    int *dimensions;
+    intptr_t *dimensions;
     // Pointer to actual data.
     char *data;
 } OIFArray;

--- a/include/oif/backend_c/qeq.h
+++ b/include/oif/backend_c/qeq.h
@@ -1,6 +1,10 @@
 #ifndef _QEQ_H_
 #define _QEQ_H_
 
-int solve_qeq(double a, double b, double c, double *roots);
+#include "dispatch.h"
+
+int solve_qeq(double a, double b, double c, OIFArray *roots);
+
+int solve_qeq_v1(double a, double b, double c, double *roots);
 
 #endif // _QEQ_H_

--- a/src/oif/backend_c/CMakeLists.txt
+++ b/src/oif/backend_c/CMakeLists.txt
@@ -2,4 +2,6 @@ cmake_minimum_required(VERSION 3.18)
 
 project(qeq LANGUAGES C)
 
-add_library(oif_backend_c SHARED qeq.c)
+add_library(oif_backend_c SHARED qeq_impl.c qeq.c)
+target_include_directories(oif_backend_c PUBLIC ${CMAKE_SOURCE_DIR})
+target_include_directories(oif_backend_c PUBLIC ${CMAKE_SOURCE_DIR}/include/oif/backend_c)

--- a/src/oif/backend_c/qeq.c
+++ b/src/oif/backend_c/qeq.c
@@ -3,17 +3,7 @@
 #include <stdlib.h>
 
 
-/**
- * Solve quadratic equation ax**2 + bx + c = 0
- * Assumes that the output array `roots` always has two elements,
- * so if the roots are repeated, they both will be still present.
- * @param a Coefficient before x**2
- * @param b Coefficient before x
- * @param c Free term
- * @param roots Array with two elements to which the found roots are written.
- * @return int
- */
-int solve_qeq(double a, double b, double c, double *roots)
+int solve_qeq_v1(double a, double b, double c, double *roots)
 {
     if (roots == NULL) {
         fprintf(stderr, "Memory for the roots array was not provided\n");

--- a/src/oif/backend_c/qeq_impl.c
+++ b/src/oif/backend_c/qeq_impl.c
@@ -1,0 +1,20 @@
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "qeq.h"
+
+
+/**
+ * Solve quadratic equation ax**2 + bx + c = 0
+ * Assumes that the output array `roots` always has two elements,
+ * so if the roots are repeated, they both will be still present.
+ * @param a Coefficient before x**2
+ * @param b Coefficient before x
+ * @param c Free term
+ * @param roots Array with two elements to which the found roots are written.
+ * @return int
+ */
+int solve_qeq(double a, double b, double c, OIFArray *roots) {
+    solve_qeq_v1(a, b, c, (double *) roots->data);
+}

--- a/src/oif/backend_python/backend_python.c
+++ b/src/oif/backend_python/backend_python.c
@@ -67,8 +67,10 @@ int run_interface_method_python(const char *method, OIFArgs *in_args, OIFArgs *o
             if (in_args->arg_types[i] == OIF_FLOAT64) {
                 pValue = PyFloat_FromDouble(*(double *)in_args->arg_values[i]);
             } else if (in_args->arg_types[i] == OIF_FLOAT64_P) {
-                const long shape[] = {2};
-                pValue = PyArray_SimpleNewFromData(1, shape, NPY_DOUBLE, in_args->arg_values[i]);
+                OIFArray *arr = (OIFArray *) in_args->arg_values[i];
+                pValue = PyArray_SimpleNewFromData(
+                    arr->nd, arr->dimensions, NPY_FLOAT64, *(double **) arr->data
+                );
             }
             if (!pValue) {
                 Py_DECREF(pArgs);
@@ -83,12 +85,10 @@ int run_interface_method_python(const char *method, OIFArgs *in_args, OIFArgs *o
             if (out_args->arg_types[i] == OIF_FLOAT64) {
                 pValue = PyFloat_FromDouble(*(double *)out_args->arg_values[i]);
             } else if (out_args->arg_types[i] == OIF_FLOAT64_P) {
-                fprintf(stderr, "Oh Gott! Remove hardcoded values ASAP\n");
-                npy_intp shape[] = {2};
-                void **p = out_args->arg_values[i];
-                double *data = *p;
-                Py_INCREF(data);
-                pValue = PyArray_SimpleNewFromData(1, shape, NPY_FLOAT64, data);
+                OIFArray *arr = (OIFArray *) out_args->arg_values[i];
+                pValue = PyArray_SimpleNewFromData(
+                    arr->nd, arr->dimensions, NPY_FLOAT64, *(double **) arr->data
+                );
             }
             if (!pValue) {
                 Py_DECREF(pArgs);

--- a/src/oif/backend_python/backend_python.c
+++ b/src/oif/backend_python/backend_python.c
@@ -84,9 +84,9 @@ int run_interface_method_python(const char *method, OIFArgs *in_args, OIFArgs *o
             if (out_args->arg_types[i] == OIF_FLOAT64) {
                 pValue = PyFloat_FromDouble(*(double *)out_args->arg_values[i]);
             } else if (out_args->arg_types[i] == OIF_FLOAT64_P) {
-                OIFArray *arr = (OIFArray *) out_args->arg_values[i];
+                OIFArray *arr = *(OIFArray **) out_args->arg_values[i];
                 pValue = PyArray_SimpleNewFromData(
-                    arr->nd, arr->dimensions, NPY_FLOAT64, *(double **) arr->data
+                    arr->nd, arr->dimensions, NPY_FLOAT64, (double *) arr->data
                 );
             }
             if (!pValue) {

--- a/src/oif/backend_python/backend_python.c
+++ b/src/oif/backend_python/backend_python.c
@@ -42,9 +42,8 @@ int run_interface_method_python(const char *method, OIFArgs *in_args, OIFArgs *o
     PyObject *pFileName, *pModule, *pFunc;
     PyObject *pArgs, *pValue;
 
-    printf("Provided module name: %s\n", method);
+    printf("[backend_python] Provided module name: %s\n", method);
     pFileName = PyUnicode_FromString(method);
-    printf("PyUnicode_FromString module name: %s\n", PyUnicode_AsUTF8(pFileName));
 
     pModule = PyImport_Import(pFileName);
     Py_DECREF(pFileName);
@@ -52,7 +51,7 @@ int run_interface_method_python(const char *method, OIFArgs *in_args, OIFArgs *o
     if (pModule == NULL)
     {
         PyErr_Print();
-        fprintf(stderr, "Failed to load \"%s\"\n", method);
+        fprintf(stderr, "[backend_python] Failed to load \"%s\"\n", method);
         return EXIT_FAILURE;
     }
 
@@ -75,7 +74,7 @@ int run_interface_method_python(const char *method, OIFArgs *in_args, OIFArgs *o
             if (!pValue) {
                 Py_DECREF(pArgs);
                 Py_DECREF(pModule);
-                fprintf(stderr, "Cannot convert argument\n");
+                fprintf(stderr, "[backend_python] Cannot convert argument\n");
                 return 1;
             }
             PyTuple_SetItem(pArgs, i, pValue);

--- a/src/oif/core.py
+++ b/src/oif/core.py
@@ -87,13 +87,13 @@ class OIFBackend:
             elif isinstance(arg, np.ndarray):
                 print("Warning: we assume that dtype is np.float64")
                 nd = arg.ndim
-                shape = (ctypes.c_int * len(arg.shape))(*arg.shape)
-                arg_p = ctypes.pointer(arg.ctypes.data_as(ctypes.c_void_p))
-                data = ctypes.cast(arg_p, ctypes.POINTER(ctypes.c_char))
+                dimensions = (ctypes.c_int * len(arg.shape))(*arg.shape)
+                data = arg.ctypes.data_as(ctypes.POINTER(ctypes.c_char))
 
-                oif_array = OIFArray(nd, shape, data)
+                oif_array = OIFArray(nd, dimensions, data)
                 oif_array_p = ctypes.cast(ctypes.byref(oif_array), ctypes.c_void_p)
-                out_arg_values.append(oif_array_p)
+                oif_array_p_p = ctypes.cast(ctypes.byref(oif_array_p), ctypes.c_void_p)
+                out_arg_values.append(oif_array_p_p)
                 out_arg_types.append(OIF_FLOAT64_P)
             else:
                 raise ValueError("Cannot handle argument type")

--- a/src/oif/core.py
+++ b/src/oif/core.py
@@ -119,12 +119,15 @@ class OIFBackend:
                 ctypes.POINTER(OIFArgs),
             ],
         )
-        call_interface_method(
+        status = call_interface_method(
             self.handle,
             method.encode(),
             ctypes.byref(args_packed),
             ctypes.byref(out_packed),
         )
+
+        if status != 0:
+            raise RuntimeError("Could not execute interface method")
 
         # result = []
         # print("Output arguments after call_interface_method")

--- a/tests/oif/backend_c/test_qeq.cpp
+++ b/tests/oif/backend_c/test_qeq.cpp
@@ -7,7 +7,7 @@ extern "C" {
 
 TEST(QeqTestSuite, LinearCase) {
     double roots[2];
-    solve_qeq(0.0, 2.0, -1.0, roots);
+    solve_qeq_v1(0.0, 2.0, -1.0, roots);
     EXPECT_EQ(roots[0], 0.5);
     EXPECT_EQ(roots[1], 0.5);
 }
@@ -15,7 +15,7 @@ TEST(QeqTestSuite, LinearCase) {
 
 TEST(QeqTestSuite, TwoRoots) {
     double roots[2];
-    solve_qeq(1.0, 2.0, 1.0, roots);
+    solve_qeq_v1(1.0, 2.0, 1.0, roots);
     EXPECT_EQ(roots[0], -1.0);
     EXPECT_EQ(roots[1], -1.0);
 }


### PR DESCRIPTION
This PR implements passing arrays between frontends and backends as `OIFArray` (see issue #11) that encodes array data and its shape.
Necessary changes are done to the Python frontend and Python and C backends. Because C implementations are in general do not work with data structures such as `OIFArray`, I have added a new component in the C backend for the quadratic equation solver that accepts such arrays (needed for the `roots` array that saves the roots of the equation) but delegates to the actual implementation.

Closes #11 