### PR TITLE
Load backends dynamically and make them implement the same interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,6 @@ endif()
 add_library(oif_dispatch SHARED dispatch.c)
 target_compile_features(oif_dispatch PUBLIC c_std_11)
 target_include_directories(oif_dispatch PUBLIC .)
-target_link_libraries(oif_dispatch PUBLIC ffi)
-target_link_libraries(oif_dispatch PRIVATE oif_backend_python)
 
 add_subdirectory(src/oif)
 
@@ -31,6 +29,7 @@ enable_testing()
 add_executable(test_qeq tests/oif/backend_c/test_qeq.cpp)
 target_link_libraries(test_qeq GTest::gtest_main oif_backend_c)
 target_include_directories(test_qeq PUBLIC include)
+target_include_directories(test_qeq PUBLIC ${CMAKE_SOURCE_DIR})
 target_compile_features(test_qeq PUBLIC cxx_std_11)
 set_target_properties(test_qeq PROPERTIES CXX_EXTENSIONS OFF)
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ all :
 	cmake --build build && \
 	cp build/liboif_dispatch.$(DSO_EXT) . && \
 	cp build/src/oif/backend_c/liboif_backend_c.$(DSO_EXT) .
+	cp build/src/oif/backend_python/liboif_backend_python.$(DSO_EXT) .
 
 .PHONY : test
 test :

--- a/dispatch.h
+++ b/dispatch.h
@@ -41,14 +41,23 @@ enum
     BACKEND_JULIA = 3,
     BACKEND_R = 4,
 };
+#define OIF_BACKEND_COUNT 5
 
-char OIF_BACKEND_C_SO[] = "./liboif_backend_c.so";
+/// Array containing handles to the opened dynamic libraries for the backends.
+/**
+ * Array containing handles  to the backend dynamic libraries.
+ * If some backend is not open, corresponding element is NULL.
+ *
+ * Each backend is responsible for populating this array with the library
+ * handle.
+ */
+void *OIF_BACKEND_HANDLES[OIF_BACKEND_COUNT];
 
 
 /**
  * Load backend by its name and version information.
  */
-BackendHandle load_backend(
+BackendHandle load_backend_by_name(
         const char *backend_name,
         const char *operation,
         size_t version_major,
@@ -56,14 +65,7 @@ BackendHandle load_backend(
 );
 
 
-BackendHandle load_backend_c(
-        const char *operation,
-        size_t version_major,
-        size_t version_minor
-);
-
-
-BackendHandle load_backend_python(
+BackendHandle load_backend(
         const char *operation,
         size_t version_major,
         size_t version_minor
@@ -78,6 +80,4 @@ int call_interface_method(
 );
 
 
-int run_interface_method_c(const char *method, OIFArgs *in_args, OIFArgs *out_args);
-
-int run_interface_method_python(const char *method, OIFArgs *in_args, OIFArgs *out_args);
+int run_interface_method(const char *method, OIFArgs *in_args, OIFArgs *out_args);

--- a/src/oif/backend_c/CMakeLists.txt
+++ b/src/oif/backend_c/CMakeLists.txt
@@ -1,7 +1,10 @@
+# Backend C
 cmake_minimum_required(VERSION 3.18)
-
+ 
 project(qeq LANGUAGES C)
 
-add_library(oif_backend_c SHARED qeq_impl.c qeq.c)
-target_include_directories(oif_backend_c PUBLIC ${CMAKE_SOURCE_DIR})
+add_library(oif_backend_c SHARED backend_c.c qeq_impl.c qeq.c)
+target_include_directories(oif_backend_c PRIVATE ${CMAKE_SOURCE_DIR})
 target_include_directories(oif_backend_c PUBLIC ${CMAKE_SOURCE_DIR}/include/oif/backend_c)
+target_link_libraries(oif_backend_c PUBLIC ffi)
+

--- a/src/oif/backend_c/backend_c.c
+++ b/src/oif/backend_c/backend_c.c
@@ -1,0 +1,104 @@
+#include <dlfcn.h>
+#include <ffi.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dispatch.h"
+#include "globals.h"
+
+
+BackendHandle load_backend(
+    const char *operation,
+    size_t version_major,
+    size_t version_minor)
+{
+
+    return BACKEND_C;
+}
+
+
+int run_interface_method(const char *method, OIFArgs *in_args, OIFArgs *out_args)
+{
+    void *func = dlsym(OIF_BACKEND_HANDLES[BACKEND_C], method);
+    if (func == NULL)
+    {
+        fprintf(stderr, "[dispatch] Cannot load interface '%s'\n", method);
+        exit(EXIT_FAILURE);
+    }
+
+    int num_in_args = in_args->num_args;
+    int num_out_args = out_args->num_args;
+    int num_total_args = num_in_args + num_out_args;
+
+    ffi_cif cif;
+    ffi_type **arg_types = malloc(num_total_args * sizeof(ffi_type));
+    void **arg_values = malloc(num_total_args * sizeof(void *));
+
+    // Merge input and output argument types together in `arg_types` array.
+    for (size_t i = 0; i < num_in_args; ++i)
+    {
+        if (in_args->arg_types[i] == OIF_FLOAT64)
+        {
+            arg_types[i] = &ffi_type_double;
+        }
+        else if (in_args->arg_types[i] == OIF_FLOAT64_P)
+        {
+            arg_types[i] = &ffi_type_pointer;
+        }
+        else
+        {
+            fflush(stdout);
+            fprintf(stderr, "[dispatch] Unknown input arg type: %d\n", in_args->arg_types[i]);
+            exit(EXIT_FAILURE);
+        }
+    }
+    for (size_t i = num_in_args; i < num_total_args; ++i)
+    {
+        printf("Processing out_args[%zu] = %u\n", i - num_in_args, out_args->arg_types[i - num_in_args]);
+        if (out_args->arg_types[i - num_in_args] == OIF_FLOAT64)
+        {
+            arg_types[i] = &ffi_type_double;
+        }
+        else if (out_args->arg_types[i - num_in_args] == OIF_FLOAT64_P)
+        {
+            arg_types[i] = &ffi_type_pointer;
+        }
+        else
+        {
+            fflush(stdout);
+            fprintf(stderr, "[dispatch] Unknown output arg type: %d\n", out_args->arg_types[i - num_in_args]);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    ffi_status status = ffi_prep_cif(&cif, FFI_DEFAULT_ABI, num_total_args, &ffi_type_uint, arg_types);
+    if (status == FFI_OK)
+    {
+        printf("[backend_c] ffi_prep_cif returned FFI_OK\n");
+    }
+    else
+    {
+        fflush(stdout);
+        fprintf(stderr, "[dispatch] ffi_prep_cif was not OK");
+        exit(EXIT_FAILURE);
+    }
+
+    // Merge input and output argument values together in `arg_values` array.
+    for (size_t i = 0; i < num_in_args; ++i)
+    {
+        arg_values[i] = in_args->arg_values[i];
+    }
+    for (size_t i = num_in_args; i < num_total_args; ++i)
+    {
+        arg_values[i] = out_args->arg_values[i - num_in_args];
+    }
+
+    unsigned result;
+    ffi_call(&cif, FFI_FN(func), &result, arg_values);
+
+    printf("Result is %u\n", result);
+    fflush(stdout);
+
+    return 0;
+}
+

--- a/src/oif/backend_python/backend_python.c
+++ b/src/oif/backend_python/backend_python.c
@@ -10,7 +10,7 @@
 #include "globals.h"
 
 
-BackendHandle load_backend_python(
+BackendHandle load_backend(
     const char *operation,
     size_t version_major,
     size_t version_minor)
@@ -37,7 +37,7 @@ BackendHandle load_backend_python(
 }
 
 
-int run_interface_method_python(const char *method, OIFArgs *in_args, OIFArgs *out_args)
+int run_interface_method(const char *method, OIFArgs *in_args, OIFArgs *out_args)
 {
     PyObject *pFileName, *pModule, *pFunc;
     PyObject *pArgs, *pValue;

--- a/src/oif/core.py
+++ b/src/oif/core.py
@@ -141,7 +141,7 @@ class OIFBackend:
 def init_backend(backend: str, interface: str, major: UInt, minor: UInt):
     load_backend = wrap_c_function(
         _lib_dispatch,
-        "load_backend",
+        "load_backend_by_name",
         ctypes.c_uint,
         [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint, ctypes.c_uint],
     )


### PR DESCRIPTION
This PR implements issue #7.

The connecting library loads backends for C and Python dynamically.
These backends are rewritten such that they implement the same interface.