### PR TITLE
Rename OIFArray to OIFArray64 and make `data` member `double *`

### DIFF
--- a/examples/call_qeq_from_c.c
+++ b/examples/call_qeq_from_c.c
@@ -41,17 +41,17 @@ int main(int argc, char *argv[])
     printf("for a = %g, b = %g, c = %g\n", a, b, c);
 
     intptr_t dimensions[] = {2,};
-    OIFArray *roots = create_array_f64(1, dimensions);
+    OIFArrayF64 *roots = create_array_f64(1, dimensions);
     int status = oif_solve_qeq(bh, a, b, c, roots);
     if (status) {
-        free_array(roots);
+        free_array_f64(roots);
         return EXIT_FAILURE;
     }
 
     printf("x1 = %g\n", ((double *) roots->data)[0]);
     printf("x2 = %g\n", ((double *) roots->data)[1]);
 
-    free_array(roots);
+    free_array_f64(roots);
 
     return 0;
 }

--- a/include/oif/api.h
+++ b/include/oif/api.h
@@ -12,7 +12,7 @@ typedef enum {
     OIF_FLOAT32 = 2,
     OIF_FLOAT64 = 3,
     OIF_FLOAT32_P = 4,
-    OIF_FLOAT64_P = 5,
+    OIF_ARRAY_F64 = 5,
     OIF_STR = 6,
 } OIFArgType;
 
@@ -30,11 +30,11 @@ typedef struct {
     // Size of each axis, i = 0, .., nd-1.
     intptr_t *dimensions;
     // Pointer to actual data.
-    char *data;
-} OIFArray;
+    double *data;
+} OIFArrayF64;
 
-OIFArray *create_array_f64(int nd, intptr_t *dimensions);
-void free_array(OIFArray *x);
+OIFArrayF64 *create_array_f64(int nd, intptr_t *dimensions);
+void free_array_f64(OIFArrayF64 *x);
 
 BackendHandle
 oif_init_backend(

--- a/include/oif/backend_c/qeq.h
+++ b/include/oif/backend_c/qeq.h
@@ -3,7 +3,7 @@
 
 #include "dispatch.h"
 
-int solve_qeq(double a, double b, double c, OIFArray *roots);
+int solve_qeq(double a, double b, double c, OIFArrayF64 *roots);
 
 int solve_qeq_v1(double a, double b, double c, double *roots);
 

--- a/include/oif/frontend_c/qeq.h
+++ b/include/oif/frontend_c/qeq.h
@@ -3,5 +3,5 @@
 #include <oif/api.h>
 
 int oif_solve_qeq(
-    BackendHandle bh, double a, double b, double c, OIFArray *roots
+    BackendHandle bh, double a, double b, double c, OIFArrayF64 *roots
 );

--- a/src/oif/backend_c/backend_c.c
+++ b/src/oif/backend_c/backend_c.c
@@ -6,6 +6,7 @@
 
 #include "dispatch.h"
 #include "globals.h"
+#include "oif/api.h"
 
 
 BackendHandle load_backend(
@@ -72,7 +73,7 @@ int run_interface_method(const char *method, OIFArgs *in_args, OIFArgs *out_args
         {
             arg_types[i] = &ffi_type_double;
         }
-        else if (in_args->arg_types[i] == OIF_FLOAT64_P)
+        else if (in_args->arg_types[i] == OIF_ARRAY_F64)
         {
             arg_types[i] = &ffi_type_pointer;
         }
@@ -90,7 +91,7 @@ int run_interface_method(const char *method, OIFArgs *in_args, OIFArgs *out_args
         {
             arg_types[i] = &ffi_type_double;
         }
-        else if (out_args->arg_types[i - num_in_args] == OIF_FLOAT64_P)
+        else if (out_args->arg_types[i - num_in_args] == OIF_ARRAY_F64)
         {
             arg_types[i] = &ffi_type_pointer;
         }

--- a/src/oif/backend_c/qeq_impl.c
+++ b/src/oif/backend_c/qeq_impl.c
@@ -15,6 +15,7 @@
  * @param roots Array with two elements to which the found roots are written.
  * @return int
  */
-int solve_qeq(double a, double b, double c, OIFArray *roots) {
-    solve_qeq_v1(a, b, c, (double *) roots->data);
+int solve_qeq(double a, double b, double c, OIFArrayF64 *roots) {
+    int status = solve_qeq_v1(a, b, c, roots->data);
+    return status;
 }

--- a/src/oif/backend_python/backend_python.c
+++ b/src/oif/backend_python/backend_python.c
@@ -1,3 +1,4 @@
+#include "oif/api.h"
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <numpy/arrayobject.h>
@@ -84,10 +85,10 @@ int run_interface_method(const char *method, OIFArgs *in_args, OIFArgs *out_args
         for (int i = 0; i < in_args->num_args; ++i) {
             if (in_args->arg_types[i] == OIF_FLOAT64) {
                 pValue = PyFloat_FromDouble(*(double *)in_args->arg_values[i]);
-            } else if (in_args->arg_types[i] == OIF_FLOAT64_P) {
-                OIFArray *arr = (OIFArray *) in_args->arg_values[i];
+            } else if (in_args->arg_types[i] == OIF_ARRAY_F64) {
+                OIFArrayF64 *arr = *(OIFArrayF64 **) in_args->arg_values[i];
                 pValue = PyArray_SimpleNewFromData(
-                    arr->nd, arr->dimensions, NPY_FLOAT64, *(double **) arr->data
+                    arr->nd, arr->dimensions, NPY_FLOAT64, arr->data
                 );
             }
             if (!pValue) {
@@ -102,10 +103,10 @@ int run_interface_method(const char *method, OIFArgs *in_args, OIFArgs *out_args
         for (int i = 0; i < out_args->num_args; ++i) {
             if (out_args->arg_types[i] == OIF_FLOAT64) {
                 pValue = PyFloat_FromDouble(*(double *)out_args->arg_values[i]);
-            } else if (out_args->arg_types[i] == OIF_FLOAT64_P) {
-                OIFArray *arr = *(OIFArray **) out_args->arg_values[i];
+            } else if (out_args->arg_types[i] == OIF_ARRAY_F64) {
+                OIFArrayF64 *arr = *(OIFArrayF64 **) out_args->arg_values[i];
                 pValue = PyArray_SimpleNewFromData(
-                    arr->nd, arr->dimensions, NPY_FLOAT64, (double *) arr->data
+                    arr->nd, arr->dimensions, NPY_FLOAT64, arr->data
                 );
             }
             if (!pValue) {

--- a/src/oif/core.py
+++ b/src/oif/core.py
@@ -10,7 +10,7 @@ OIF_INT = 1
 OIF_FLOAT32 = 2
 OIF_FLOAT64 = 3
 OIF_FLOAT32_P = 4
-OIF_FLOAT64_P = 5
+OIF_ARRAY_F64 = 5
 OIF_STR = 6
 
 
@@ -59,7 +59,7 @@ class OIFBackend:
                 arg_p = ctypes.pointer(arg.data.as_type(ctypes.c_void_p))
                 arg_p_void = ctypes.cast(arg_p, ctypes.c_void_p)
                 arg_values.append(arg_p_void)
-                arg_types.append(OIF_FLOAT64_P)
+                arg_types.append(OIF_ARRAY_F64)
             else:
                 raise ValueError("Cannot handle argument type")
 
@@ -94,7 +94,7 @@ class OIFBackend:
                 oif_array_p = ctypes.cast(ctypes.byref(oif_array), ctypes.c_void_p)
                 oif_array_p_p = ctypes.cast(ctypes.byref(oif_array_p), ctypes.c_void_p)
                 out_arg_values.append(oif_array_p_p)
-                out_arg_types.append(OIF_FLOAT64_P)
+                out_arg_types.append(OIF_ARRAY_F64)
             else:
                 raise ValueError("Cannot handle argument type")
 
@@ -128,12 +128,6 @@ class OIFBackend:
 
         if status != 0:
             raise RuntimeError("Could not execute interface method")
-
-        # result = []
-        # print("Output arguments after call_interface_method")
-        # for typ, val in zip(out_arg_types, out_arg_values):
-        #     if typ == OIF_FLOAT64_P:
-        #         result.append(out_arg_values)
 
         return 0
 

--- a/src/oif/frontend_c/frontend_c.c
+++ b/src/oif/frontend_c/frontend_c.c
@@ -9,8 +9,8 @@ oif_init_backend(
 }
 
 
-OIFArray *create_array_f64(int nd, intptr_t *dimensions) {
-    OIFArray *x = malloc(sizeof(OIFArray));
+OIFArrayF64 *create_array_f64(int nd, intptr_t *dimensions) {
+    OIFArrayF64 *x = malloc(sizeof(OIFArrayF64));
     x->nd = nd;
     x->dimensions = dimensions;
 
@@ -18,13 +18,13 @@ OIFArray *create_array_f64(int nd, intptr_t *dimensions) {
     for (size_t i = 0; i < nd; ++i) {
         size *= dimensions[i];
     }
-    x->data = (char *) malloc(size * sizeof(double));
+    x->data = (double *) malloc(size * sizeof(double));
 
     return x;
 }
 
 
-void free_array(OIFArray *x) {
+void free_array_f64(OIFArrayF64 *x) {
     if (x == NULL) {
         return;
     }

--- a/src/oif/frontend_c/qeq.c
+++ b/src/oif/frontend_c/qeq.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 
 int oif_solve_qeq(
-    BackendHandle bh, double a, double b, double c, OIFArray *roots
+    BackendHandle bh, double a, double b, double c, OIFArrayF64 *roots
 ) {
     OIFArgType in_arg_types[3] = {OIF_FLOAT64, OIF_FLOAT64, OIF_FLOAT64};
     void *in_arg_values[3] = {(void *)&a, (void *)&b, (void *)&c};
@@ -14,7 +14,7 @@ int oif_solve_qeq(
         .arg_values = in_arg_values,
     };
 
-    OIFArgType out_arg_types[] = {OIF_FLOAT64_P};
+    OIFArgType out_arg_types[] = {OIF_ARRAY_F64};
     void *out_arg_values[] = {&roots};
     OIFArgs out_args = {
         .num_args = 1,


### PR DESCRIPTION
This PR removes replaces data structure `OIFArray` with the structure `OIFArrayF64` that explicitly works with double-precision floating-point data type (analogous to C `double *` arrays).

Closes #15 