### PR TITLE
Fix build on macOS

### DIFF
--- a/environment-macos.yaml
+++ b/environment-macos.yaml
@@ -4,12 +4,13 @@ channels:
     - conda-forge
 
 dependencies:
-    - python=3.10
+    - python=3.11
     - cmake=3.18
     - pip
     - c-compiler=1.5.1
-    - cxx-compiler=1.3.0
+    - cxx-compiler=1.5.1
     - fortran-compiler
+    - numpy
     - openblas
     - pytest
     - python-dotenv
@@ -17,3 +18,6 @@ dependencies:
     - black
     - mypy
     - isort
+    - pip:
+        - sphinx
+        - myst_parser

--- a/include/oif/dispatch.h
+++ b/include/oif/dispatch.h
@@ -1,18 +1,10 @@
 #pragma once
+#ifndef OIF_DISPATCH_H
+#define OIF_DISPATCH_H
 #include <stdint.h>
 #include <stdlib.h>
 
 #include <oif/api.h>
-
-/// Array containing handles to the opened dynamic libraries for the backends.
-/**
- * Array containing handles  to the backend dynamic libraries.
- * If some backend is not open, corresponding element is NULL.
- *
- * Each backend is responsible for populating this array with the library
- * handle.
- */
-void *OIF_BACKEND_HANDLES[OIF_BACKEND_COUNT];
 
 
 /**
@@ -32,3 +24,4 @@ int call_interface_method(
     OIFArgs *args,
     OIFArgs *retvals
 );
+#endif

--- a/src/oif/dispatch.c
+++ b/src/oif/dispatch.c
@@ -13,6 +13,16 @@
 char OIF_BACKEND_C_SO[] =      "./liboif_backend_c.so";
 char OIF_BACKEND_PYTHON_SO[] = "./liboif_backend_python.so";
 
+/// Array containing handles to the opened dynamic libraries for the backends.
+/**
+ * Array containing handles  to the backend dynamic libraries.
+ * If some backend is not open, corresponding element is NULL.
+ *
+ * Each backend is responsible for populating this array with the library
+ * handle.
+ */
+void *OIF_BACKEND_HANDLES[OIF_BACKEND_COUNT];
+
 
 BackendHandle load_backend_by_name(
     const char *backend_name,

--- a/src/oif/frontend_c/frontend_c.c
+++ b/src/oif/frontend_c/frontend_c.c
@@ -1,4 +1,3 @@
-#include <oif/api.h>
 #include <oif/dispatch.h>
 
 


### PR DESCRIPTION
Update `mamba` (`conda`) environment on macos with missing dependencies as the attempt to update the environment file with `sphinx` for building documentation has failed.

With Clang 14, there was an error with redefinition of the array `OIF_BACKEND_HANDLES`, which is fixed by moving the array to `dispatch.c` where it is used.