### PR TITLE
[cmake] Set policy only if it is available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,9 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 # DOWNLOAD_EXTRACT_TIMESTAMP = TRUE
-cmake_policy(SET CMP0135 NEW)
+if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+endif()
 
 add_subdirectory(src/oif)
 


### PR DESCRIPTION
When using older versions of CMake, policy CMP0135 is not available, which leads to a failing build. As this policy is not essential, this PR turns this policy on only if it is known to CMake.