### PR TITLE
Replace `backend` with `impl` for user-facing code

### DIFF
--- a/examples/call_linsolve_from_c.c
+++ b/examples/call_linsolve_from_c.c
@@ -35,8 +35,8 @@ int main(int argc, char *argv[])
         1, (intptr_t [1]){2}, (double [2]){6.0, 2.0}
     );
 
-    ImplHandle implh = oif_init_backend("linsolve", impl, 1, 0);
-    if (implh == OIF_BACKEND_INIT_ERROR) {
+    ImplHandle implh = oif_init_impl("linsolve", impl, 1, 0);
+    if (implh == OIF_IMPL_INIT_ERROR) {
         fprintf(stderr, "Error during implementation initialization. Cannot proceed\n");
         return EXIT_FAILURE;
     }

--- a/examples/call_qeq_from_c.c
+++ b/examples/call_qeq_from_c.c
@@ -32,8 +32,8 @@ int main(int argc, char *argv[])
     double b = 5.0;
     double c = 4.0;
 
-    ImplHandle implh = oif_init_backend("qeq", impl, 1, 0);
-    if (implh == OIF_BACKEND_INIT_ERROR) {
+    ImplHandle implh = oif_init_impl("qeq", impl, 1, 0);
+    if (implh == OIF_IMPL_INIT_ERROR) {
         fprintf(stderr, "Error during implementation initialization. Cannot proceed\n");
         return EXIT_FAILURE;
     }

--- a/oif/dispatch.c
+++ b/oif/dispatch.c
@@ -25,7 +25,7 @@ void *OIF_BACKEND_HANDLES[OIF_BACKEND_COUNT];
 typedef unsigned int BackendHandle;
 
 
-ImplHandle load_backend_by_name(
+ImplHandle load_interface_impl(
     const char *interface,
     const char *impl,
     size_t version_major,

--- a/oif/include/oif/api.h
+++ b/oif/include/oif/api.h
@@ -42,9 +42,5 @@ typedef struct {
 
 enum {
     OIF_ERROR = 101,
-    OIF_BACKEND_INIT_ERROR = 102,
+    OIF_IMPL_INIT_ERROR = 102,
 };
-
-ImplHandle
-oif_init_backend(
-    const char *backend, const char *interface, int major, int minor);

--- a/oif/include/oif/c_bindings.h
+++ b/oif/include/oif/c_bindings.h
@@ -1,9 +1,18 @@
 #pragma once
 #include <oif/api.h>
 
+/**
+ * Initialize interface implementation.
+ * @param interface Name of the interface
+ * @param implementation Name of the implementation
+ * @param version_major  Major version number of the implementation
+ * @param version_minor  Minor version number of the implementation
+ * @return positive number that identifies the requested implementation
+ *         or OIF_IMPL_INIT_ERROR in case of the error
+ */
 ImplHandle
-oif_init_backend(
-    const char *interface, const char *impl, int major, int minor
+oif_init_impl(
+    const char *interface, const char *impl, int version_major, int version_minor
 );
 
 OIFArrayF64 *

--- a/oif/include/oif/dispatch.h
+++ b/oif/include/oif/dispatch.h
@@ -8,9 +8,16 @@
 
 
 /**
- * Load implementation by its name and version information.
+ * Load implementation of the interface.
+ *
+ * @param interface     Name of the interface
+ * @param impl          Name of the implementation for the interface
+ * @param version_major Major version number of the implementation
+ * @param version_minor Minor version number of the implementation
+ * @return positive number that identifies the requested implementation
+ *         or OIF_IMPL_INIT_ERROR in case of the error
  */
-ImplHandle load_backend_by_name(
+ImplHandle load_interface_impl(
         const char *interface,
         const char *impl,
         size_t version_major,

--- a/oif/interfaces/python/oif/interfaces/linear_solver.py
+++ b/oif/interfaces/python/oif/interfaces/linear_solver.py
@@ -1,12 +1,12 @@
 import numpy as np
-from oif.core import OIFBackend, init_backend
+from oif.core import OIFPyBinding, init_impl
 
 
 class LinearSolver:
     def __init__(self, impl: str):
-        self.backend: OIFBackend = init_backend("linsolve", impl, 1, 0)
+        self._binding: OIFPyBinding = init_impl("linsolve", impl, 1, 0)
 
     def solve(self, A: np.ndarray, b: np.ndarray) -> np.ndarray:
         result = np.empty((A.shape[1]))
-        self.backend.call("solve_lin", (A, b), (result,))
+        self._binding.call("solve_lin", (A, b), (result,))
         return result

--- a/oif/interfaces/python/oif/interfaces/qeq_solver.py
+++ b/oif/interfaces/python/oif/interfaces/qeq_solver.py
@@ -1,12 +1,12 @@
 import numpy as np
-from oif.core import OIFBackend, init_backend
+from oif.core import OIFPyBinding, init_impl
 
 
 class QeqSolver:
     def __init__(self, impl: str):
-        self.backend: OIFBackend = init_backend("qeq", impl, 1, 0)
+        self._binding: OIFPyBinding = init_impl("qeq", impl, 1, 0)
 
     def solve(self, a: float, b: float, c: float):
         result = np.array([11.0, 22.0])
-        self.backend.call("solve_qeq", (a, b, c), (result,))
+        self._binding.call("solve_qeq", (a, b, c), (result,))
         return result

--- a/oif/lang_c/c_bindings.c
+++ b/oif/lang_c/c_bindings.c
@@ -7,9 +7,9 @@
 
 
 ImplHandle
-oif_init_backend(
-    const char *interface, const char *impl, int major, int minor) {
-    return load_backend_by_name(interface, impl, major, minor);
+oif_init_impl(
+    const char *interface, const char *impl, int version_major, int version_minor) {
+    return load_interface_impl(interface, impl, version_major, version_minor);
 }
 
 

--- a/oif_impl/c/dispatch_c.c
+++ b/oif_impl/c/dispatch_c.c
@@ -87,7 +87,6 @@ int run_interface_method(const char *method, OIFArgs *in_args, OIFArgs *out_args
     }
     for (size_t i = num_in_args; i < num_total_args; ++i)
     {
-        printf("Processing out_args[%zu] = %u\n", i - num_in_args, out_args->arg_types[i - num_in_args]);
         if (out_args->arg_types[i - num_in_args] == OIF_FLOAT64)
         {
             arg_types[i] = &ffi_type_double;

--- a/oif_impl/python/dispatch_python.c
+++ b/oif_impl/python/dispatch_python.c
@@ -49,7 +49,7 @@ ImplHandle load_backend(
 
     import_array2(
         "Failed to initialize NumPy C API",
-        OIF_BACKEND_INIT_ERROR
+        OIF_IMPL_INIT_ERROR
     );
 
     PyRun_SimpleString(


### PR DESCRIPTION
This PR improve API of the code that the user works directly with. Precisely, mentions of `backend` are replaced with `impl` (short for `implementation`), for example, C function `oif_init_backend` is renamed as `oif_init_impl`.

Additionally, Python bindings for `qeq` and `linsolve` interfaces do not use word `backend` anymore but `binding` instead.