### PR TITLE
Refactor dispatch libraries

### DIFF
--- a/oif/include/oif/api.h
+++ b/oif/include/oif/api.h
@@ -5,16 +5,6 @@
 // Handle to an instantiated implementation.
 typedef int ImplHandle;
 
-enum
-{
-    BACKEND_C = 1,
-    BACKEND_CXX = 2,
-    BACKEND_PYTHON = 3,
-    BACKEND_JULIA = 4,
-    BACKEND_R = 5,
-    OIF_BACKEND_COUNT = 6,
-};
-
 typedef enum {
     OIF_INT = 1,
     OIF_FLOAT32 = 2,

--- a/oif/include/oif/dispatch_api.h
+++ b/oif/include/oif/dispatch_api.h
@@ -4,6 +4,16 @@
  */
 #include <oif/api.h>
 
+enum
+{
+    OIF_LANG_C = 1,
+    OIF_LANG_CXX = 2,
+    OIF_LANG_PYTHON = 3,
+    OIF_LANG_JULIA = 4,
+    OIF_LANG_R = 5,
+    OIF_LANG_COUNT = 6,
+};
+
 
 ImplHandle load_backend(
         const char *impl_details,

--- a/oif_impl/c/dispatch_c.c
+++ b/oif_impl/c/dispatch_c.c
@@ -42,7 +42,7 @@ ImplHandle load_backend(
     }
     IMPL->impl_lib = impl_lib;
     
-    ImplHandle implh = 1000 * BACKEND_C + IMPL_COUNTER;
+    ImplHandle implh = 1000 * OIF_LANG_C + IMPL_COUNTER;
     IMPL_COUNTER++;
     return implh;
 }

--- a/oif_impl/python/dispatch_python.c
+++ b/oif_impl/python/dispatch_python.c
@@ -115,7 +115,7 @@ ImplHandle load_backend(
     IMPL = malloc(sizeof(PythonImpl));
     IMPL->pInstance = pInstance;
 
-    ImplHandle implh = 1000 * BACKEND_PYTHON + IMPL_COUNTER;
+    ImplHandle implh = 1000 * OIF_LANG_PYTHON + IMPL_COUNTER;
     IMPL_COUNTER++;
 
     return implh;


### PR DESCRIPTION
This PR cleans the code in the `dispatch` library and the language-specific dispatch libraries by removing the word backend, renaming constants for language-specific dispatches.