### PR TITLE
Organize loaded implementations in hashmap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ endif()
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
+add_subdirectory(vendor)
+
 add_subdirectory(oif)
 file(COPY oif_impl DESTINATION ${CMAKE_BINARY_DIR})
 add_subdirectory(oif_impl)

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,7 @@ endif
 .PHONY : all
 all :
 	cmake -S . -B build -DCMAKE_VERBOSE_MAKEFILE:BOOL=FALSE -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON && \
-	cmake --build build && \
-	cp build/oif/liboif_dispatch.$(DSO_EXT) . && \
-	cp build/oif/lang_c/liboif_c.$(DSO_EXT) .
-	cp build/oif_impl/c/liboif_dispatch_c.$(DSO_EXT) .
-	cp build/oif_impl/python/liboif_dispatch_python.$(DSO_EXT) .
-	cp build/oif_impl/impl/qeq/c_qeq_solver/liboif_qeq_c_qeq_solver.$(DSO_EXT) .
-	cp build/oif_impl/impl/linsolve/c_lapack/liboif_linsolve_c_lapack.$(DSO_EXT) .
+	cmake --build build
 
 .PHONY : test
 test : all

--- a/oif/CMakeLists.txt
+++ b/oif/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_library(oif_dispatch SHARED dispatch.c)
 target_include_directories(oif_dispatch PUBLIC ${CMAKE_SOURCE_DIR}/include)
 target_include_directories(oif_dispatch PUBLIC ${CMAKE_SOURCE_DIR}/oif/include)
+target_include_directories(oif_dispatch PRIVATE ${CMAKE_SOURCE_DIR}/vendor/hashmap)
+target_link_libraries(oif_dispatch PRIVATE HashMap::HashMap)
 
 add_subdirectory(lang_c)
 

--- a/oif/dispatch.c
+++ b/oif/dispatch.c
@@ -11,8 +11,8 @@
 #include <oif/dispatch_api.h>
 
 
-char OIF_DISPATCH_C_SO[] =      "./liboif_dispatch_c.so";
-char OIF_DISPATCH_PYTHON_SO[] = "./liboif_dispatch_python.so";
+char OIF_DISPATCH_C_SO[] =      "liboif_dispatch_c.so";
+char OIF_DISPATCH_PYTHON_SO[] = "liboif_dispatch_python.so";
 
 /**
  * Array of handles to the dynamically loaded libraries

--- a/oif/include/oif/dispatch_api.h
+++ b/oif/include/oif/dispatch_api.h
@@ -14,16 +14,30 @@ enum
     OIF_LANG_COUNT = 6,
 };
 
+// Identifier for the language-specific dispatch library (C, Python, etc.).
+typedef unsigned int DispatchHandle;
 
-ImplHandle load_backend(
-        const char *impl_details,
-        size_t version_major,
-        size_t version_minor
+/**
+ * Base structure for implementation details.
+ * Language-specific implementations can add extra members to the subtypes
+ * of `Impl`, however, they must not set `implh` and `dh` themselves
+ * as this is a responsibility of the `dispatch` library.
+ */
+typedef struct {
+    ImplHandle implh;
+    DispatchHandle dh;
+} ImplInfo;
+
+
+ImplInfo *load_backend(
+    const char *impl_details,
+    size_t version_major,
+    size_t version_minor
 );
 
 
 int
 run_interface_method(
-    const char *method, OIFArgs *in_args, OIFArgs *out_args
+    ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *out_args
 );
 

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(hashmap)


### PR DESCRIPTION
The `dispatch` library now asks language-specific dispatches to create `ImpInfo` substructures with the necessary information, saves them in a hashmap, and passes to respective language-specific dispatches when method invocation is requested by the user.