### PR TITLE
[cmake] Fetch and build hashmap library

### DIFF
--- a/oif/CMakeLists.txt
+++ b/oif/CMakeLists.txt
@@ -1,9 +1,7 @@
 add_library(oif_dispatch SHARED dispatch.c)
 target_include_directories(oif_dispatch PUBLIC ${CMAKE_SOURCE_DIR}/include)
 target_include_directories(oif_dispatch PUBLIC ${CMAKE_SOURCE_DIR}/oif/include)
-target_include_directories(oif_dispatch PRIVATE ${CMAKE_SOURCE_DIR}/vendor/hashmap)
 target_link_libraries(oif_dispatch PRIVATE HashMap::HashMap)
 
 add_subdirectory(lang_c)
-
 

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -1,1 +1,9 @@
-add_subdirectory(hashmap)
+include(FetchContent)
+FetchContent_Declare(
+  hashmap
+  GIT_REPOSITORY https://github.com/DavidLeeds/hashmap
+  GIT_TAG master
+)
+
+FetchContent_MakeAvailable(hashmap)
+


### PR DESCRIPTION
Fix an issue with the build system, that the `hashmap` library was not fetched and built automatically.