### PR TITLE
Add interface for initial-value problems and one implementation 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ if(POLICY CMP0135)
     cmake_policy(SET CMP0135 NEW)
 endif()
 
+# Copy all built library targets to a common directory, so that it is
+# easy to find and load them.
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_subdirectory(vendor)

--- a/examples/call_ivp_from_python.py
+++ b/examples/call_ivp_from_python.py
@@ -22,8 +22,8 @@ def _parse_args():
     return Args(**vars(args))
 
 
-def rhs(x):
-    return -x
+def rhs(t, y):
+    return -y
 
 
 def main():
@@ -35,14 +35,15 @@ def main():
     s.set_rhs_fn(rhs)
     t0 = 0.0
     y0 = [1.0]
-    s.set_initial_value(t0, y0)
+    s.set_initial_value(y0, t0)
 
     times = np.linspace(t0, t0 + 1, num=11)
 
-    y = np.empty_like(y0)
+    soln = [y0[0]]
     for t in times[1:]:
-        s.integrate(t, y)
-        print(f"{t} {y}")
+        s.integrate(t)
+        print(f"{t:.3f} {s.y[0]:.6f}")
+        soln.append(s.y[0])
 
 
 if __name__ == "__main__":

--- a/examples/call_ivp_from_python.py
+++ b/examples/call_ivp_from_python.py
@@ -1,0 +1,49 @@
+import argparse
+import dataclasses
+
+import numpy as np
+from oif.interfaces.ivp import IVP
+
+
+@dataclasses.dataclass
+class Args:
+    impl: str
+
+
+def _parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "impl",
+        choices=["scipy_ode_dopri5"],
+        default="scipy_ode_dopri5",
+        nargs="?",
+    )
+    args = p.parse_args()
+    return Args(**vars(args))
+
+
+def rhs(x):
+    return -x
+
+
+def main():
+    args = _parse_args()
+    impl = args.impl
+    print("Calling from Python an open interface for quadratic solver")
+    print(f"Implementation: {impl}")
+    s = IVP(impl)
+    s.set_rhs_fn(rhs)
+    t0 = 0.0
+    y0 = [1.0]
+    s.set_initial_value(t0, y0)
+
+    times = np.linspace(t0, t0 + 1, num=11)
+
+    y = np.empty_like(y0)
+    for t in times[1:]:
+        s.integrate(t, y)
+        print(f"{t} {y}")
+
+
+if __name__ == "__main__":
+    main()

--- a/oif/include/oif/api.h
+++ b/oif/include/oif/api.h
@@ -31,6 +31,13 @@ typedef struct {
     double *data;
 } OIFArrayF64;
 
+// This structure is used for callback functions.
+typedef struct {
+    int src;       // Language of the function (one of OIF_LANG_* constants)
+    void *fn_p;    // Function pointer in this language
+    void *c_fn_p;  // C function pointer (can be NULL)
+} OIFCallback;
+
 enum {
     OIF_ERROR = 101,
     OIF_IMPL_INIT_ERROR = 102,

--- a/oif/include/oif/api.h
+++ b/oif/include/oif/api.h
@@ -12,6 +12,7 @@ typedef enum {
     OIF_FLOAT32_P = 4,
     OIF_ARRAY_F64 = 5,
     OIF_STR = 6,
+    OIF_CALLBACK = 7,
 } OIFArgType;
 
 typedef struct {

--- a/oif/interfaces/python/oif/interfaces/ivp.py
+++ b/oif/interfaces/python/oif/interfaces/ivp.py
@@ -6,15 +6,24 @@ class IVP:
     def __init__(self, impl: str):
         self._binding: OIFPyBinding = init_impl("ivp", impl, 1, 0)
         self.s = None
+        self.y0: np.ndarray
+        self.y: np.ndarray
 
     def set_rhs_fn(self, rhs_fn):
+        x = np.array([1.0, 2.0])
+        if len(rhs_fn(2.718, x)) != len(x):
+            raise ValueError("Right-hand-side function has signature problems")
+
+        # TODO: Think more about the signature of rhs function in C
         wrapper = wrap_py_func(rhs_fn, (OIF_ARRAY_F64, OIF_ARRAY_F64), OIF_INT)
         self._binding.call("set_rhs_fn", (wrapper,), ())
 
-    def set_initial_value(self, t0, y0):
+    def set_initial_value(self, y0, t0):
+        y0 = np.asarray(y0, dtype=np.float64)
+        self.y0 = y0
+        self.y = np.empty_like(y0)
         t0 = float(t0)
-        y0 = np.asarray(y0)
-        self._binding.call("set_initial_value", (t0, y0), ())
+        self._binding.call("set_initial_value", (y0, t0), ())
 
-    def integrate(self, t, y):
-        self._binding.call("integrate", (t,), (y,))
+    def integrate(self, t):
+        self._binding.call("integrate", (t,), (self.y,))

--- a/oif/interfaces/python/oif/interfaces/ivp.py
+++ b/oif/interfaces/python/oif/interfaces/ivp.py
@@ -9,16 +9,12 @@ class IVP:
 
     def set_rhs_fn(self, rhs_fn):
         wrapper = wrap_py_func(rhs_fn, (OIF_ARRAY_F64, OIF_ARRAY_F64), OIF_INT)
-        status = 0
-        self._binding.call("set_rhs_fn", (wrapper,), (status,))
+        self._binding.call("set_rhs_fn", (wrapper,), ())
 
     def set_initial_value(self, t0, y0):
         t0 = float(t0)
         y0 = np.asarray(y0)
-        # I request returning an integer, as functions without
-        # return values do not work right now.
-        status = 0
-        self._binding.call("set_initial_value", (t0, y0), (status,))
+        self._binding.call("set_initial_value", (t0, y0), ())
 
     def integrate(self, t, y):
         self._binding.call("integrate", (t,), (y,))

--- a/oif/interfaces/python/oif/interfaces/ivp.py
+++ b/oif/interfaces/python/oif/interfaces/ivp.py
@@ -1,0 +1,24 @@
+import numpy as np
+from oif.core import OIF_ARRAY_F64, OIF_INT, OIFPyBinding, init_impl, wrap_py_func
+
+
+class IVP:
+    def __init__(self, impl: str):
+        self._binding: OIFPyBinding = init_impl("ivp", impl, 1, 0)
+        self.s = None
+
+    def set_rhs_fn(self, rhs_fn):
+        wrapper = wrap_py_func(rhs_fn, (OIF_ARRAY_F64, OIF_ARRAY_F64), OIF_INT)
+        status = 0
+        self._binding.call("set_rhs_fn", (wrapper,), (status,))
+
+    def set_initial_value(self, t0, y0):
+        t0 = float(t0)
+        y0 = np.asarray(y0)
+        # I request returning an integer, as functions without
+        # return values do not work right now.
+        status = 0
+        self._binding.call("set_initial_value", (t0, y0), (status,))
+
+    def integrate(self, t, y):
+        self._binding.call("integrate", (t,), (y,))

--- a/oif/lang_python/oif/core.py
+++ b/oif/lang_python/oif/core.py
@@ -15,6 +15,9 @@ OIF_STR = 6
 OIF_CALLBACK = 7
 
 
+_lib_dispatch = ctypes.PyDLL("liboif_dispatch.so")
+
+
 class OIFArgType(ctypes.c_int):
     pass
 
@@ -73,9 +76,6 @@ def wrap_py_func(
     return wrapper_fn
 
 
-_lib_dispatch = ctypes.PyDLL("./liboif_dispatch.so")
-
-
 class OIFPyBinding:
     def __init__(self, implh):
         self.implh = implh
@@ -111,6 +111,7 @@ class OIFPyBinding:
                 arg_types.append(OIF_ARRAY_F64)
             elif isinstance(arg, ctypes._CFuncPtr):
                 argp = ctypes.pointer(arg)
+                print(f"Input argument as CFuncPtr = {arg}")
                 arg_values.append(ctypes.cast(argp, ctypes.c_void_p))
                 arg_types.append(OIF_CALLBACK)
             else:

--- a/oif_impl/impl/ivp/scipy_ode_dopri5/dopri5.py
+++ b/oif_impl/impl/ivp/scipy_ode_dopri5/dopri5.py
@@ -1,3 +1,4 @@
+import numpy as np
 from scipy import integrate
 
 
@@ -7,6 +8,9 @@ class Dopri5:
 
     def set_rhs_fn(self, rhs):
         self.rhs = rhs
+
+        x = np.array([1.0, 2.0])
+        assert len(self.rhs(x)) == len(x)
 
         return 0
 

--- a/oif_impl/impl/ivp/scipy_ode_dopri5/dopri5.py
+++ b/oif_impl/impl/ivp/scipy_ode_dopri5/dopri5.py
@@ -9,15 +9,18 @@ class Dopri5:
     def set_rhs_fn(self, rhs):
         self.rhs = rhs
 
-        x = np.array([1.0, 2.0])
-        assert len(self.rhs(x)) == len(x)
-
         return 0
 
-    def set_initial_value(self, t0, y0):
-        self.s = integrate.ode(self.rhs).set_integrator("dopri5")
+    def set_initial_value(self, y0, t0):
+        if not isinstance(t0, float):
+            raise ValueError("Argument `t0` must be floating-point number")
+
+        self.s = integrate.ode(self.rhs).set_integrator(
+            "dopri5", atol=1e-15, rtol=1e-15
+        )
         self.s.set_initial_value(y0, t0)
 
     def integrate(self, t, y):
         y[:] = self.s.integrate(t)
+        assert self.s.successful()
         return 0

--- a/oif_impl/impl/ivp/scipy_ode_dopri5/dopri5.py
+++ b/oif_impl/impl/ivp/scipy_ode_dopri5/dopri5.py
@@ -1,0 +1,19 @@
+from scipy import integrate
+
+
+class Dopri5:
+    def __init__(self):
+        self.rhs = None
+
+    def set_rhs_fn(self, rhs):
+        self.rhs = rhs
+
+        return 0
+
+    def set_initial_value(self, t0, y0):
+        self.s = integrate.ode(self.rhs).set_integrator("dopri5")
+        self.s.set_initial_value(y0, t0)
+
+    def integrate(self, t, y):
+        y[:] = self.s.integrate(t)
+        return 0

--- a/oif_impl/impl/ivp/scipy_ode_dopri5/scipy_ode_dopri5.conf
+++ b/oif_impl/impl/ivp/scipy_ode_dopri5/scipy_ode_dopri5.conf
@@ -1,0 +1,2 @@
+python
+ivp.scipy_ode_dopri5.dopri5 Dopri5

--- a/oif_impl/python/dispatch_python.c
+++ b/oif_impl/python/dispatch_python.c
@@ -149,8 +149,15 @@ int run_interface_method(ImplInfo *impl_info, const char *method, OIFArgs *in_ar
                     arr->nd, arr->dimensions, NPY_FLOAT64, arr->data
                 );
             } else if (in_args->arg_types[i] == OIF_CALLBACK) {
-                void *p = in_args->arg_values[i];
-                pValue = *(PyObject **) p;
+                OIFCallback *p = in_args->arg_values[i];
+                if (p->src != OIF_LANG_PYTHON) {
+                    fprintf(
+                        stderr,
+                        "[dispatch_python] Can handle only Python callable\n"
+                    );
+                    exit(1);
+                }
+                pValue = (PyObject *) p->fn_p;
                 if (!PyCallable_Check(pValue)) {
                     fprintf(
                         stderr,

--- a/tests/lang_python/test_ivp.py
+++ b/tests/lang_python/test_ivp.py
@@ -1,0 +1,69 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+from oif.interfaces.ivp import IVP
+
+
+def rhs(_, y):
+    return -y
+
+
+class TestIVPViaScipyODEDopri5Implementation:
+    @pytest.fixture(
+        params=[
+            "scipy_ode_dopri5",
+        ]
+    )
+    def s(self, request):
+        return IVP(request.param)
+
+    def rhs_method(self, _, y):
+        return -y
+
+    def test_1(self, s):
+        s.set_rhs_fn(rhs)
+        t0 = 0.0
+        y0 = np.array([1.0])
+        s.set_initial_value(y0, t0)
+
+        times = np.linspace(t0, t0 + 1, num=11)
+
+        soln = [y0[0]]
+        for t in times[1:]:
+            s.integrate(t)
+            soln.append(s.y[0])
+
+        # Solution is y(t) = e^(-t), so y(1) = 0.367879.
+        npt.assert_allclose(soln[-1], 0.367879, rtol=1e-4)
+
+    def test_2_accept_rhs_fn_method(self, s):
+        s.set_rhs_fn(self.rhs_method)
+        t0 = 0.0
+        y0 = np.array([1.0])
+        s.set_initial_value(y0, t0)
+
+        times = np.linspace(t0, t0 + 1, num=11)
+
+        soln = [y0[0]]
+        for t in times[1:]:
+            s.integrate(t)
+            soln.append(s.y[0])
+
+        # Solution is y(t) = e^(-t), so y(1) = 0.367879.
+        npt.assert_allclose(soln[-1], 0.367879, rtol=1e-4)
+
+    def test_3_test_accept_int_list_for_y0_and_int_for_t0(self, s):
+        s.set_rhs_fn(rhs)
+        t0 = 0
+        y0 = [1]
+        s.set_initial_value(y0, t0)
+
+        times = np.linspace(t0, t0 + 1, num=11)
+
+        soln = [y0[0]]
+        for t in times[1:]:
+            s.integrate(t)
+            soln.append(s.y[0])
+
+        # Solution is y(t) = e^(-t), so y(1) = 0.367879.
+        npt.assert_allclose(soln[-1], 0.367879, rtol=1e-4)


### PR DESCRIPTION
This pull request adds an interface for initial value problems (`IVP`) in Python and also one implementation in Python via [`scipy.intergrate.ode`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.ode.html) package with `dopri5` integrator.

Interface is chosen to follow closely the basic interface of the `scipy.integrate.ode` package:

- `set_rhs_fn` sets right-hand side function (this is different from `ode`)
- `set_initial_value(y0, t0)` to set initial values (the same as in `ode`)
- `integrate(t)` integrates from the previous time to the given time `t`
- integrator interface (`IVP` class on the user side) exhibits solution at time `t` via property `.y`, which user can print or copy
- The above design decision is taken (along with keeping references to the `rhs_fn` and `y0`) to make sure that all these objects are not garbage collected, so that the pointers on the implementation side are valid.

Example usage is in `example/call_ivp_from_python.py`.