### PR TITLE
Add unit tests for IVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ Testing/
 
 # Visual Studio Code
 .vscode/
+
+# cmake_wrapper.sh is a script to force VSCode use conda environment.
+cmake_wrapper.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,8 @@ set_target_properties(test_linsolve PROPERTIES CXX_EXTENSIONS OFF)
 add_executable(test_ivp tests/lang_c/test_ivp.cpp)
 target_link_libraries(test_ivp GTest::gtest_main oif_c)
 target_include_directories(test_ivp PUBLIC ${CMAKE_SOURCE_DIR}/oif/include)
-target_include_directories(test_ivp PUBLIC ${CMAKE_SOURCE_DIR}/oif/interfaces/c/include)
+target_include_directories(test_ivp
+                           PUBLIC ${CMAKE_SOURCE_DIR}/oif/interfaces/c/include)
 target_compile_features(test_ivp PUBLIC cxx_std_11)
 set_target_properties(test_ivp PROPERTIES CXX_EXTENSIONS OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,17 @@ target_include_directories(test_linsolve
 target_compile_features(test_linsolve PUBLIC cxx_std_11)
 set_target_properties(test_linsolve PROPERTIES CXX_EXTENSIONS OFF)
 
+add_executable(test_ivp tests/lang_c/test_ivp.cpp)
+target_link_libraries(test_ivp GTest::gtest_main oif_c)
+target_include_directories(test_ivp PUBLIC ${CMAKE_SOURCE_DIR}/oif/include)
+target_include_directories(test_ivp PUBLIC ${CMAKE_SOURCE_DIR}/oif/interfaces/c/include)
+target_compile_features(test_ivp PUBLIC cxx_std_11)
+set_target_properties(test_ivp PROPERTIES CXX_EXTENSIONS OFF)
+
 include(GoogleTest)
 gtest_discover_tests(test_qeq)
 gtest_discover_tests(test_linsolve)
+gtest_discover_tests(test_ivp)
 
 include(CTest)
 add_test(NAME test_qeq COMMAND test_qeq)

--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,5 @@ all :
 
 .PHONY : test
 test : all
-	pytest tests/lang_python
 	cd build && ctest
+	pytest tests/lang_python

--- a/examples/call_ivp_from_python.py
+++ b/examples/call_ivp_from_python.py
@@ -14,7 +14,7 @@ def _parse_args():
     p = argparse.ArgumentParser()
     p.add_argument(
         "impl",
-        choices=["scipy_ode_dopri5"],
+        choices=["scipy_ode_dopri5", "sundials_cvode"],
         default="scipy_ode_dopri5",
         nargs="?",
     )

--- a/oif/include/oif/c_bindings.h
+++ b/oif/include/oif/c_bindings.h
@@ -18,7 +18,7 @@ ImplHandle oif_init_impl(const char *interface,
 OIFArrayF64 *oif_create_array_f64(int nd, intptr_t *dimensions);
 
 OIFArrayF64 *
-oif_init_array_f64_from_data(int nd, intptr_t *dimensions, double *data);
+oif_init_array_f64_from_data(int nd, intptr_t *dimensions, const double *data);
 
 void oif_free_array_f64(OIFArrayF64 *x);
 

--- a/oif/interfaces/python/oif/interfaces/ivp.py
+++ b/oif/interfaces/python/oif/interfaces/ivp.py
@@ -1,5 +1,15 @@
+import ctypes
+
 import numpy as np
-from oif.core import OIF_ARRAY_F64, OIF_INT, OIFPyBinding, init_impl, wrap_py_func
+from oif.core import (
+    OIF_ARRAY_F64,
+    OIF_FLOAT64,
+    OIF_INT,
+    OIFArrayF64,
+    OIFPyBinding,
+    init_impl,
+    wrap_py_func,
+)
 
 
 class IVP:
@@ -8,20 +18,38 @@ class IVP:
         self.s = None
         self.y0: np.ndarray
         self.y: np.ndarray
+        self.N: int
 
     def set_rhs_fn(self, rhs_fn):
         x = np.array([1.0, 2.0])
         if len(rhs_fn(2.718, x)) != len(x):
             raise ValueError("Right-hand-side function has signature problems")
 
-        # TODO: Think more about the signature of rhs function in C
-        wrapper = wrap_py_func(rhs_fn, (OIF_ARRAY_F64, OIF_ARRAY_F64), OIF_INT)
-        self._binding.call("set_rhs_fn", (wrapper,), ())
+        def rhs_fn_w(
+            t: float, y: ctypes.POINTER(OIFArrayF64), y_dot: ctypes.POINTER(OIFArrayF64)
+        ):
+            assert y is not None
+            assert y_dot is not None
+            assert y.contents.dimensions[0] == self.N, (
+                "Assertion that y->dimensions == N has failed. "
+                f"Actual value of y->dimensions is {y.contents.dimensions}"
+            )
+            assert y_dot.contents.dimensions[0] == self.N
+            y_np = np.ctypeslib.as_array(y.contents.data, shape=(self.N,))
+            y_dot_np = np.ctypeslib.as_array(y_dot.contents.data, shape=(self.N,))
+            y_dot_np[:] = rhs_fn(t, y_np)
+            return 0
+
+        self.wrapper = wrap_py_func(
+            rhs_fn, rhs_fn_w, (OIF_FLOAT64, OIF_ARRAY_F64, OIF_ARRAY_F64), OIF_INT
+        )
+        self._binding.call("set_rhs_fn", (self.wrapper,), ())
 
     def set_initial_value(self, y0, t0):
         y0 = np.asarray(y0, dtype=np.float64)
         self.y0 = y0
         self.y = np.empty_like(y0)
+        self.N = len(self.y0)
         t0 = float(t0)
         self._binding.call("set_initial_value", (y0, t0), ())
 

--- a/oif/lang_c/c_bindings.c
+++ b/oif/lang_c/c_bindings.c
@@ -27,7 +27,7 @@ OIFArrayF64 *oif_create_array_f64(int nd, intptr_t *dimensions) {
 }
 
 OIFArrayF64 *
-oif_init_array_f64_from_data(int nd, intptr_t *dimensions, double *data) {
+oif_init_array_f64_from_data(int nd, intptr_t *dimensions, const double *data) {
     OIFArrayF64 *x = oif_create_array_f64(nd, dimensions);
     int size = 1;
     for (size_t i = 0; i < nd; ++i) {

--- a/oif_impl/c/dispatch_c.c
+++ b/oif_impl/c/dispatch_c.c
@@ -103,11 +103,8 @@ int run_interface_method(ImplInfo *impl_info,
         }
     }
 
-    ffi_status status = ffi_prep_cif(
-        &cif, FFI_DEFAULT_ABI, num_total_args, &ffi_type_uint, arg_types);
-    if (status == FFI_OK) {
-        // printf("[dispatch_c] ffi_prep_cif returned FFI_OK\n");
-    } else {
+    ffi_status status = ffi_prep_cif(&cif, FFI_DEFAULT_ABI, num_total_args, &ffi_type_uint, arg_types);
+    if (status != FFI_OK) {
         fflush(stdout);
         fprintf(stderr, "[dispatch_c] ffi_prep_cif was not OK");
         exit(EXIT_FAILURE);
@@ -123,9 +120,6 @@ int run_interface_method(ImplInfo *impl_info,
 
     unsigned result;
     ffi_call(&cif, FFI_FN(func), &result, arg_values);
-
-    // printf("Result is %u\n", result);
-    fflush(stdout);
 
     return 0;
 }

--- a/oif_impl/c/dispatch_c.c
+++ b/oif_impl/c/dispatch_c.c
@@ -81,6 +81,13 @@ int run_interface_method(ImplInfo *impl_info,
                     "correctly\n");
             in_args->arg_values[i] =
                 ((OIFCallback *)in_args->arg_values[i])->c_fn_p;
+            fprintf(stderr,
+                    "[dispatch_c] WARN: in_args->arg_values[i] = %p\n",
+                    in_args->arg_values[i]);
+            fprintf(stderr,
+                    "[dispatch_c] WARN: *in_args->arg_values[i] = %p\n",
+                    *(*(void (*)(double, OIFArrayF64 *, OIFArrayF64 *))
+                           in_args->arg_values[i]));
         } else {
             fflush(stdout);
             fprintf(stderr,
@@ -103,7 +110,8 @@ int run_interface_method(ImplInfo *impl_info,
         }
     }
 
-    ffi_status status = ffi_prep_cif(&cif, FFI_DEFAULT_ABI, num_total_args, &ffi_type_uint, arg_types);
+    ffi_status status = ffi_prep_cif(
+        &cif, FFI_DEFAULT_ABI, num_total_args, &ffi_type_uint, arg_types);
     if (status != FFI_OK) {
         fflush(stdout);
         fprintf(stderr, "[dispatch_c] ffi_prep_cif was not OK");
@@ -120,6 +128,9 @@ int run_interface_method(ImplInfo *impl_info,
 
     unsigned result;
     ffi_call(&cif, FFI_FN(func), &result, arg_values);
+
+    free(arg_values);
+    free(arg_types);
 
     return 0;
 }

--- a/oif_impl/impl/ivp/scipy_ode_dopri5/dopri5.py
+++ b/oif_impl/impl/ivp/scipy_ode_dopri5/dopri5.py
@@ -11,9 +11,9 @@ class Dopri5:
     def set_rhs_fn(self, rhs):
         self.rhs = rhs
 
-        x = np.array([3.0])
-        assert len(self.rhs(42.0, x)) == len(x)
-        print("after check")
+        # x = np.array([3.0])
+        # assert len(self.rhs(42.0, x)) == len(x)
+        # print("after check")
 
         return 0
 

--- a/oif_impl/impl/ivp/scipy_ode_dopri5/dopri5.py
+++ b/oif_impl/impl/ivp/scipy_ode_dopri5/dopri5.py
@@ -1,6 +1,8 @@
 import numpy as np
 from scipy import integrate
 
+_prefix = "scipy_ode_dopri5"
+
 
 class Dopri5:
     def __init__(self):
@@ -9,14 +11,23 @@ class Dopri5:
     def set_rhs_fn(self, rhs):
         self.rhs = rhs
 
+        x = np.array([3.0])
+        assert len(self.rhs(42.0, x)) == len(x)
+        print("after check")
+
         return 0
 
     def set_initial_value(self, y0: np.ndarray, t0: float):
+        _p = f"[{_prefix}::set_initial_value]"
+
         if not isinstance(t0, float):
-            raise ValueError("Argument `t0` must be floating-point number")
+            raise ValueError(f"{_p} Argument `t0` must be floating-point number")
+
+        if self.rhs is None:
+            raise TypeError(f"{_p} Method `set_rhs_fn` must be called earlier")
 
         self.s = integrate.ode(self.rhs).set_integrator(
-            "dopri5", atol=1e-15, rtol=1e-15
+            "dopri5", atol=1e-15, rtol=1e-15, nsteps=1000
         )
         self.s.set_initial_value(y0, t0)
 

--- a/oif_impl/impl/ivp/sundials_cvode/sundials_cvode.c
+++ b/oif_impl/impl/ivp/sundials_cvode/sundials_cvode.c
@@ -110,6 +110,8 @@ int set_initial_value(OIFArrayF64 *y0_in, double t0_in) {
     // 15. Set nonlinear solver optional inputs (optional)
     // 16. Specify rootfinding problem (optional)
 
+    N_VDestroy_Serial(y0);
+
     return 0;
 }
 
@@ -131,6 +133,7 @@ int integrate(double t, OIFArrayF64 *y) {
 
     // 17. Advance solution in time.
     ier = CVode(cvode_mem, tout, yout, &tret, CV_NORMAL);
+    N_VDestroy(yout);
     // TODO: Handle all cases: write good error messages for all `ier`.
     switch (ier) {
     case CV_SUCCESS:
@@ -142,7 +145,7 @@ int integrate(double t, OIFArrayF64 *y) {
     }
 }
 
-// Simple function that calculates the differential equation.
+// Function that computes the right-hand side of the ODE system.
 static int cvode_rhs(realtype t, N_Vector y, N_Vector ydot, void *user_data) {
     // While Sundials CVode works with `N_Vector` data structure
     // for one-dimensional arrays, the user provides right-hand side
@@ -160,5 +163,5 @@ static int cvode_rhs(realtype t, N_Vector y, N_Vector ydot, void *user_data) {
 
     OIF_RHS_FN(t, &oif_y, &oif_ydot);
 
-    return (0);
+    return 0;
 }

--- a/oif_impl/impl/ivp/sundials_cvode/sundials_cvode.c
+++ b/oif_impl/impl/ivp/sundials_cvode/sundials_cvode.c
@@ -73,7 +73,7 @@ int set_initial_value(OIFArrayF64 *y0_in, double t0_in) {
     assert(t0 == t0_in);
 
     // 5. Create CVODE object.
-    cvode_mem = CVodeCreate(CV_BDF, sunctx);
+    cvode_mem = CVodeCreate(CV_ADAMS, sunctx);
 
     // 6. Initialize CVODE solver.
     status = CVodeInit(cvode_mem, cvode_rhs, t0, y0);

--- a/oif_impl/impl/ivp/sundials_cvode/sundials_cvode.c
+++ b/oif_impl/impl/ivp/sundials_cvode/sundials_cvode.c
@@ -42,6 +42,10 @@ static SUNContext sunctx;
 void *cvode_mem;
 
 int set_initial_value(OIFArrayF64 *y0_in, double t0_in) {
+    if ((y0_in == NULL) || (y0_in->data == NULL)) {
+        fprintf(stderr, "`set_initial_value` received NULL argument\n");
+        exit(1);
+    }
     int status;              // Check errors
     realtype abstol = 1e-15; // absolute tolerance
     realtype reltol = 1e-15; // relative tolerance
@@ -112,6 +116,10 @@ int set_initial_value(OIFArrayF64 *y0_in, double t0_in) {
 }
 
 int integrate(double t, OIFArrayF64 *y) {
+    if ((y == NULL) || (y->data == NULL)) {
+        fprintf(stderr, "`integrate` received NULL argument\n");
+        exit(1);
+    }
     int ier; // Error checking.
 
     sunindextype N = y->dimensions[0];

--- a/oif_impl/impl/ivp/sundials_cvode/sundials_cvode.c
+++ b/oif_impl/impl/ivp/sundials_cvode/sundials_cvode.c
@@ -21,10 +21,6 @@
 
 const char *prefix = "[impl::sundials_cvode]";
 
-// This macro gives access to the individual components of the data array of an
-// N Vector.
-#define NV_Ith_S(v, i) (NV_DATA_S(v)[i])
-
 // Signature for the right-hand side that is provided by the `IVP` interface
 // of the OpenInterFaces.
 // TODO: Should be part of the interface header?

--- a/tests/lang_c/test_ivp.cpp
+++ b/tests/lang_c/test_ivp.cpp
@@ -9,11 +9,10 @@ extern "C" {
 }
 
 class ScalarExpDecayProblem {
-public:
+  public:
     static constexpr int N = 1;
     static constexpr double y0[] = {1.0};
-    static void
-    rhs(double t, OIFArrayF64 *y, OIFArrayF64 *rhs_out) {
+    static void rhs(double t, OIFArrayF64 *y, OIFArrayF64 *rhs_out) {
         int size = y->dimensions[0];
         for (int i = 0; i < size; ++i) {
             rhs_out->data[i] = -y->data[i];
@@ -26,27 +25,28 @@ public:
 };
 
 class LinearOscillatorProblem {
-public:
+  public:
     static constexpr int N = 2;
     static constexpr double y0[2] = {1.0, 0.5};
     static constexpr double omega = M_PI;
-    static void
-    rhs(double t, OIFArrayF64 *y, OIFArrayF64 *rhs_out) {
+    static void rhs(double t, OIFArrayF64 *y, OIFArrayF64 *rhs_out) {
         rhs_out->data[0] = y->data[1];
         rhs_out->data[1] = -omega * omega * y->data[0];
     }
     static double exact(double t, int i) {
         // Exact solution at time t, component i.
-        assert(i == 0);  // Check only the first component.
-        return y0[0] * cos(omega*t) + y0[1] * sin(omega*t) / omega;
+        assert(i == 0); // Check only the first component.
+        return y0[0] * cos(omega * t) + y0[1] * sin(omega * t) / omega;
     }
 };
 
 TEST(IvpScipyOdeDopri5TestSuite, ScalarExpDecayTestCase) {
     double t0 = 0.0;
-    intptr_t dims[] = {ScalarExpDecayProblem::N,};
-    OIFArrayF64 *y0 = oif_init_array_f64_from_data(
-        1, dims, ScalarExpDecayProblem::y0);
+    intptr_t dims[] = {
+        ScalarExpDecayProblem::N,
+    };
+    OIFArrayF64 *y0 =
+        oif_init_array_f64_from_data(1, dims, ScalarExpDecayProblem::y0);
     OIFArrayF64 *y = oif_create_array_f64(1, dims);
     ImplHandle implh = oif_init_impl("ivp", "scipy_ode_dopri5", 1, 0);
 
@@ -62,14 +62,14 @@ TEST(IvpScipyOdeDopri5TestSuite, ScalarExpDecayTestCase) {
     }
 }
 
-
 TEST(IvpScipyOdeDopri5TestSuite, LinearOscillatorTestCase) {
     double t0 = 0.0;
-    intptr_t dims[] = {LinearOscillatorProblem::N,};
-    OIFArrayF64 *y0 = oif_init_array_f64_from_data(
-        1, dims, LinearOscillatorProblem::y0
-    );
-     OIFArrayF64 *y = oif_create_array_f64(1, dims);
+    intptr_t dims[] = {
+        LinearOscillatorProblem::N,
+    };
+    OIFArrayF64 *y0 =
+        oif_init_array_f64_from_data(1, dims, LinearOscillatorProblem::y0);
+    OIFArrayF64 *y = oif_create_array_f64(1, dims);
     ImplHandle implh = oif_init_impl("ivp", "scipy_ode_dopri5", 1, 0);
 
     int status;
@@ -86,9 +86,11 @@ TEST(IvpScipyOdeDopri5TestSuite, LinearOscillatorTestCase) {
 
 TEST(IvpSundialsCvodeTestSuite, ScalarExpDecayTestCase) {
     double t0 = 0.0;
-    intptr_t dims[] = {ScalarExpDecayProblem::N,};
-    OIFArrayF64 *y0 = oif_init_array_f64_from_data(
-        1, dims, ScalarExpDecayProblem::y0);
+    intptr_t dims[] = {
+        ScalarExpDecayProblem::N,
+    };
+    OIFArrayF64 *y0 =
+        oif_init_array_f64_from_data(1, dims, ScalarExpDecayProblem::y0);
     OIFArrayF64 *y = oif_create_array_f64(1, dims);
     ImplHandle implh = oif_init_impl("ivp", "sundials_cvode", 1, 0);
 
@@ -104,14 +106,14 @@ TEST(IvpSundialsCvodeTestSuite, ScalarExpDecayTestCase) {
     }
 }
 
-
 TEST(IvpSundialsCvodeTestSuite, LinearOscillatorTestCase) {
     double t0 = 0.0;
-    intptr_t dims[] = {LinearOscillatorProblem::N,};
-    OIFArrayF64 *y0 = oif_init_array_f64_from_data(
-        1, dims, LinearOscillatorProblem::y0
-    );
-     OIFArrayF64 *y = oif_create_array_f64(1, dims);
+    intptr_t dims[] = {
+        LinearOscillatorProblem::N,
+    };
+    OIFArrayF64 *y0 =
+        oif_init_array_f64_from_data(1, dims, LinearOscillatorProblem::y0);
+    OIFArrayF64 *y = oif_create_array_f64(1, dims);
     ImplHandle implh = oif_init_impl("ivp", "sundials_cvode", 1, 0);
 
     int status;

--- a/tests/lang_c/test_ivp.cpp
+++ b/tests/lang_c/test_ivp.cpp
@@ -1,0 +1,85 @@
+#include <cmath>
+#include <cstdio>
+
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "oif/c_bindings.h"
+#include "oif/interfaces/ivp.h"
+}
+
+class ScalarExpDecayProblem {
+public:
+    static constexpr int N = 1;
+    static constexpr double y0[] = {1.0};
+    static void
+    rhs(double t, OIFArrayF64 *y, OIFArrayF64 *rhs_out) {
+        int size = y->dimensions[0];
+        for (int i = 0; i < size; ++i) {
+            rhs_out->data[i] = -y->data[i];
+        }
+    }
+    static double exact(double t, int i) {
+        // Exact solution at time t, component i.
+        return exp(-t);
+    }
+};
+
+class LinearOscillatorProblem {
+public:
+    static constexpr int N = 2;
+    static constexpr double y0[2] = {1.0, 0.5};
+    static constexpr double omega = M_PI;
+    static void
+    rhs(double t, OIFArrayF64 *y, OIFArrayF64 *rhs_out) {
+        rhs_out->data[0] = y->data[1];
+        rhs_out->data[1] = -omega * omega * y->data[0];
+    }
+    static double exact(double t, int i) {
+        // Exact solution at time t, component i.
+        assert(i == 0);  // Check only the first component.
+        return y0[0] * cos(omega*t) + y0[1] * sin(omega*t) / omega;
+    }
+};
+
+TEST(IvpScipyOdeDopri5TestSuite, ScalarExpDecayTestCase) {
+    double t0 = 0.0;
+    intptr_t dims[] = {ScalarExpDecayProblem::N,};
+    OIFArrayF64 *y0 = oif_init_array_f64_from_data(
+        1, dims, ScalarExpDecayProblem::y0);
+    OIFArrayF64 *y = oif_create_array_f64(1, dims);
+    ImplHandle implh = oif_init_impl("ivp", "scipy_ode_dopri5", 1, 0);
+
+    int status;
+    status = oif_ivp_set_rhs_fn(implh, ScalarExpDecayProblem::rhs);
+    status = oif_ivp_set_initial_value(implh, y0, t0);
+
+    double t = 0.1;
+    auto t_span = {0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 2.0};
+    for (auto t : t_span) {
+        status = oif_ivp_integrate(implh, t, y);
+        EXPECT_NEAR(y->data[0], ScalarExpDecayProblem::exact(t, 0), 1e-15);
+    }
+}
+
+
+TEST(IvpScipyOdeDopri5TestSuite, LinearOscillatorTestCase) {
+    double t0 = 0.0;
+    intptr_t dims[] = {LinearOscillatorProblem::N,};
+    OIFArrayF64 *y0 = oif_init_array_f64_from_data(
+        1, dims, LinearOscillatorProblem::y0
+    );
+     OIFArrayF64 *y = oif_create_array_f64(1, dims);
+    ImplHandle implh = oif_init_impl("ivp", "scipy_ode_dopri5", 1, 0);
+
+    int status;
+    status = oif_ivp_set_rhs_fn(implh, LinearOscillatorProblem::rhs);
+    status = oif_ivp_set_initial_value(implh, y0, t0);
+
+    double t = 0.1;
+    auto t_span = {0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 2.0};
+    for (auto t : t_span) {
+        status = oif_ivp_integrate(implh, t, y);
+        EXPECT_NEAR(y->data[0], LinearOscillatorProblem::exact(t, 0), 1e-12);
+    }
+}

--- a/tests/lang_c/test_ivp.cpp
+++ b/tests/lang_c/test_ivp.cpp
@@ -83,3 +83,45 @@ TEST(IvpScipyOdeDopri5TestSuite, LinearOscillatorTestCase) {
         EXPECT_NEAR(y->data[0], LinearOscillatorProblem::exact(t, 0), 1e-12);
     }
 }
+
+TEST(IvpSundialsCvodeTestSuite, ScalarExpDecayTestCase) {
+    double t0 = 0.0;
+    intptr_t dims[] = {ScalarExpDecayProblem::N,};
+    OIFArrayF64 *y0 = oif_init_array_f64_from_data(
+        1, dims, ScalarExpDecayProblem::y0);
+    OIFArrayF64 *y = oif_create_array_f64(1, dims);
+    ImplHandle implh = oif_init_impl("ivp", "sundials_cvode", 1, 0);
+
+    int status;
+    status = oif_ivp_set_rhs_fn(implh, ScalarExpDecayProblem::rhs);
+    status = oif_ivp_set_initial_value(implh, y0, t0);
+
+    double t = 0.1;
+    auto t_span = {0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 2.0};
+    for (auto t : t_span) {
+        status = oif_ivp_integrate(implh, t, y);
+        EXPECT_NEAR(y->data[0], ScalarExpDecayProblem::exact(t, 0), 2e-15);
+    }
+}
+
+
+TEST(IvpSundialsCvodeTestSuite, LinearOscillatorTestCase) {
+    double t0 = 0.0;
+    intptr_t dims[] = {LinearOscillatorProblem::N,};
+    OIFArrayF64 *y0 = oif_init_array_f64_from_data(
+        1, dims, LinearOscillatorProblem::y0
+    );
+     OIFArrayF64 *y = oif_create_array_f64(1, dims);
+    ImplHandle implh = oif_init_impl("ivp", "sundials_cvode", 1, 0);
+
+    int status;
+    status = oif_ivp_set_rhs_fn(implh, LinearOscillatorProblem::rhs);
+    status = oif_ivp_set_initial_value(implh, y0, t0);
+
+    double t = 0.1;
+    auto t_span = {0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 2.0};
+    for (auto t : t_span) {
+        status = oif_ivp_integrate(implh, t, y);
+        EXPECT_NEAR(y->data[0], LinearOscillatorProblem::exact(t, 0), 1e-12);
+    }
+}

--- a/tests/lang_python/test_ivp.py
+++ b/tests/lang_python/test_ivp.py
@@ -12,6 +12,7 @@ class TestIVPViaScipyODEDopri5Implementation:
     @pytest.fixture(
         params=[
             "scipy_ode_dopri5",
+            "sundials_cvode",
         ]
     )
     def s(self, request):


### PR DESCRIPTION
This PR adds unit tests to test invokations of IVP interface from C and Python with two now available implementations `scipy_ode_dopri5` and `sundials_cvode`.