### PR TITLE
Change method invokation order for the IVP interface

### DIFF
--- a/examples/call_ivp_from_c.c
+++ b/examples/call_ivp_from_c.c
@@ -48,14 +48,14 @@ int main(int argc, char *argv[]) {
     }
 
     int status; // Aux variable to check for errors.
-    status = oif_ivp_set_rhs_fn(implh, rhs);
-    if (status) {
-        fprintf(stderr, "oif_ivp_set_rhs_fn returned error\n");
-        return EXIT_FAILURE;
-    }
     status = oif_ivp_set_initial_value(implh, y0, t0);
     if (status) {
         fprintf(stderr, "oif_ivp_set_set_initial_value returned error\n");
+        return EXIT_FAILURE;
+    }
+    status = oif_ivp_set_rhs_fn(implh, rhs);
+    if (status) {
+        fprintf(stderr, "oif_ivp_set_rhs_fn returned error\n");
         return EXIT_FAILURE;
     }
 

--- a/examples/call_ivp_from_python.py
+++ b/examples/call_ivp_from_python.py
@@ -32,10 +32,10 @@ def main():
     print("Calling from Python an open interface for quadratic solver")
     print(f"Implementation: {impl}")
     s = IVP(impl)
-    s.set_rhs_fn(rhs)
     t0 = 0.0
     y0 = [1.0]
     s.set_initial_value(y0, t0)
+    s.set_rhs_fn(rhs)
 
     times = np.linspace(t0, t0 + 1, num=11)
 

--- a/oif/interfaces/python/oif/interfaces/ivp.py
+++ b/oif/interfaces/python/oif/interfaces/ivp.py
@@ -16,12 +16,14 @@ class IVP:
     def __init__(self, impl: str):
         self._binding: OIFPyBinding = init_impl("ivp", impl, 1, 0)
         self.s = None
+        self.N: int = 0
         self.y0: np.ndarray
         self.y: np.ndarray
-        self.N: int
 
     def set_rhs_fn(self, rhs_fn):
-        x = np.array([1.0, 2.0])
+        if self.N <= 0:
+            raise RuntimeError("'set_initial_value' must be called before 'set_rhs_fn'")
+        x = np.random.random(size=(self.N,))
         if len(rhs_fn(2.718, x)) != len(x):
             raise ValueError("Right-hand-side function has signature problems")
 

--- a/oif_impl/impl/ivp/scipy_ode_dopri5/dopri5.py
+++ b/oif_impl/impl/ivp/scipy_ode_dopri5/dopri5.py
@@ -6,16 +6,8 @@ _prefix = "scipy_ode_dopri5"
 
 class Dopri5:
     def __init__(self):
-        self.rhs = None
-
-    def set_rhs_fn(self, rhs):
-        self.rhs = rhs
-
-        # x = np.array([3.0])
-        # assert len(self.rhs(42.0, x)) == len(x)
-        # print("after check")
-
-        return 0
+        self.rhs = None  # Right-hand side function.
+        self.N = 0  # Problem dimension.
 
     def set_initial_value(self, y0: np.ndarray, t0: float):
         _p = f"[{_prefix}::set_initial_value]"
@@ -23,13 +15,25 @@ class Dopri5:
         if not isinstance(t0, float):
             raise ValueError(f"{_p} Argument `t0` must be floating-point number")
 
-        if self.rhs is None:
-            raise TypeError(f"{_p} Method `set_rhs_fn` must be called earlier")
+        self.y0 = y0
+        self.t0 = t0
+        self.N = len(y0)
+
+    def set_rhs_fn(self, rhs):
+        self.rhs = rhs
+
+        if self.N <= 0:
+            raise RuntimeError("`set_initial_value` must be called before `set_rhs_fn`")
+        x = np.random.random(size=(self.N,))
+        msg = "Wrong signature for the right-hand side function"
+        assert len(self.rhs(42.0, x)) == len(x), msg
 
         self.s = integrate.ode(self.rhs).set_integrator(
             "dopri5", atol=1e-15, rtol=1e-15, nsteps=1000
         )
-        self.s.set_initial_value(y0, t0)
+        self.s.set_initial_value(self.y0, self.t0)
+
+        return 0
 
     def integrate(self, t, y):
         y[:] = self.s.integrate(t)

--- a/oif_impl/impl/ivp/sundials_cvode/sundials_cvode.c
+++ b/oif_impl/impl/ivp/sundials_cvode/sundials_cvode.c
@@ -30,11 +30,6 @@ static oif_rhs_fn_t OIF_RHS_FN;
 // Signature for the right-hand side function that CVode expects.
 static int cvode_rhs(realtype t, N_Vector u, N_Vector u_dot, void *user_data);
 
-int set_rhs_fn(void rhs(double, OIFArrayF64 *y, OIFArrayF64 *y_dot)) {
-    OIF_RHS_FN = rhs;
-    return 0;
-}
-
 // Global state of the module.
 // Sundials context
 static SUNContext sunctx;
@@ -112,6 +107,16 @@ int set_initial_value(OIFArrayF64 *y0_in, double t0_in) {
 
     N_VDestroy_Serial(y0);
 
+    return 0;
+}
+
+int set_rhs_fn(void rhs(double, OIFArrayF64 *y, OIFArrayF64 *y_dot)) {
+    if (rhs == NULL) {
+        fprintf(stderr,
+                "`set_rhs_fn` accepts non-null function pointer only\n");
+        return 1;
+    }
+    OIF_RHS_FN = rhs;
     return 0;
 }
 

--- a/oif_impl/python/dispatch_python.c
+++ b/oif_impl/python/dispatch_python.c
@@ -106,8 +106,9 @@ ImplInfo *load_backend(const char *impl_details,
     PyObject *pFileName, *pModule;
     PyObject *pClass, *pInstance;
     PyObject *pInitArgs;
-    printf("[backend_python] Provided module name: '%s'\n", moduleName);
-    printf("[backend_python] Provided class name: '%s'\n", className);
+    fprintf(
+        stderr, "[backend_python] Provided module name: '%s'\n", moduleName);
+    fprintf(stderr, "[backend_python] Provided class name: '%s'\n", className);
     pFileName = PyUnicode_FromString(moduleName);
     pModule = PyImport_Import(pFileName);
     Py_DECREF(pFileName);

--- a/tests/lang_c/test_ivp.cpp
+++ b/tests/lang_c/test_ivp.cpp
@@ -51,8 +51,8 @@ TEST(IvpScipyOdeDopri5TestSuite, ScalarExpDecayTestCase) {
     ImplHandle implh = oif_init_impl("ivp", "scipy_ode_dopri5", 1, 0);
 
     int status;
-    status = oif_ivp_set_rhs_fn(implh, ScalarExpDecayProblem::rhs);
     status = oif_ivp_set_initial_value(implh, y0, t0);
+    status = oif_ivp_set_rhs_fn(implh, ScalarExpDecayProblem::rhs);
 
     double t = 0.1;
     auto t_span = {0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 2.0};
@@ -73,8 +73,8 @@ TEST(IvpScipyOdeDopri5TestSuite, LinearOscillatorTestCase) {
     ImplHandle implh = oif_init_impl("ivp", "scipy_ode_dopri5", 1, 0);
 
     int status;
-    status = oif_ivp_set_rhs_fn(implh, LinearOscillatorProblem::rhs);
     status = oif_ivp_set_initial_value(implh, y0, t0);
+    status = oif_ivp_set_rhs_fn(implh, LinearOscillatorProblem::rhs);
 
     double t = 0.1;
     auto t_span = {0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 2.0};
@@ -95,8 +95,8 @@ TEST(IvpSundialsCvodeTestSuite, ScalarExpDecayTestCase) {
     ImplHandle implh = oif_init_impl("ivp", "sundials_cvode", 1, 0);
 
     int status;
-    status = oif_ivp_set_rhs_fn(implh, ScalarExpDecayProblem::rhs);
     status = oif_ivp_set_initial_value(implh, y0, t0);
+    status = oif_ivp_set_rhs_fn(implh, ScalarExpDecayProblem::rhs);
 
     double t = 0.1;
     auto t_span = {0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 2.0};
@@ -117,8 +117,8 @@ TEST(IvpSundialsCvodeTestSuite, LinearOscillatorTestCase) {
     ImplHandle implh = oif_init_impl("ivp", "sundials_cvode", 1, 0);
 
     int status;
-    status = oif_ivp_set_rhs_fn(implh, LinearOscillatorProblem::rhs);
     status = oif_ivp_set_initial_value(implh, y0, t0);
+    status = oif_ivp_set_rhs_fn(implh, LinearOscillatorProblem::rhs);
 
     double t = 0.1;
     auto t_span = {0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 2.0};

--- a/tests/lang_python/test_ivp.py
+++ b/tests/lang_python/test_ivp.py
@@ -56,8 +56,8 @@ class LinearOscillatorProblem(IVPProblem):
 class TestIVPViaScipyODEDopri5Implementation:
     def test_1(self, s, p):
         p = ScalarExpDecayProblem()
-        s.set_rhs_fn(p.rhs)
         s.set_initial_value(p.y0, p.t0)
+        s.set_rhs_fn(p.rhs)
 
         t1 = p.t0 + 1
         times = np.linspace(p.t0, t1, num=11)
@@ -70,8 +70,8 @@ class TestIVPViaScipyODEDopri5Implementation:
         npt.assert_allclose(soln[-1], p.exact(t1), rtol=1e-4)
 
     def test_3_test_accept_int_list_for_y0_and_int_for_t0(self, s, p):
-        s.set_rhs_fn(p.rhs)
         s.set_initial_value(list(p.y0), int(p.t0))
+        s.set_rhs_fn(p.rhs)
 
         t1 = p.t0 + 1
         times = np.linspace(p.t0, t1, num=11)


### PR DESCRIPTION
Method `set_initial_value` must be invoked before `set_rhs_fn` because `set_rhs_fn` can run tests on signature correctness and for that, it is required to know the problem dimension, which can be determined from the initial value. Hence, the change in order.