### PR TITLE
Add orbit equations problem to IVP test suites

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ target_link_libraries(test_ivp GTest::gtest_main oif_c)
 target_include_directories(test_ivp PUBLIC ${CMAKE_SOURCE_DIR}/oif/include)
 target_include_directories(test_ivp
                            PUBLIC ${CMAKE_SOURCE_DIR}/oif/interfaces/c/include)
+target_include_directories(test_ivp PRIVATE ${CMAKE_SOURCE_DIR}/tests)
 target_compile_features(test_ivp PUBLIC cxx_std_11)
 set_target_properties(test_ivp PROPERTIES CXX_EXTENSIONS OFF)
 

--- a/tests/lang_c/test_ivp.cpp
+++ b/tests/lang_c/test_ivp.cpp
@@ -1,12 +1,15 @@
 #include <cmath>
 #include <cstdio>
 
+#include "testutils.h"
 #include <gtest/gtest.h>
 
 extern "C" {
 #include "oif/c_bindings.h"
 #include "oif/interfaces/ivp.h"
 }
+
+const double EPS = 0.9;
 
 class ScalarExpDecayProblem {
   public:
@@ -37,6 +40,29 @@ class LinearOscillatorProblem {
         // Exact solution at time t, component i.
         assert(i == 0); // Check only the first component.
         return y0[0] * cos(omega * t) + y0[1] * sin(omega * t) / omega;
+    }
+};
+
+class OrbitEquationsProblem {
+  public:
+    static constexpr int N = 4;
+    static constexpr double eps = 0.9L;
+    static constexpr double y0[4] = {
+        1 - eps, 0.0, 0.0, constexpr_sqrt((1 + eps) / (1 - eps))};
+    static void rhs(double t, OIFArrayF64 *y, OIFArrayF64 *rhs_out) {
+        double r = sqrt(y->data[0] * y->data[0] + y->data[1] * y->data[1]);
+        rhs_out->data[0] = y->data[2];
+        rhs_out->data[1] = y->data[3];
+        rhs_out->data[2] = -y->data[0] / (r * r * r);
+        rhs_out->data[3] = -y->data[1] / (r * r * r);
+    }
+    static double exact(double t, int i) {
+        // Exact solution at time t, component i.
+        assert(i == 0); // Check only the first component.
+
+        double u = fsolve([t](double u) { return u - eps * sin(u) - t; },
+                          [](double u) { return 1 - eps * cos(u); });
+        return cos(u) - eps;
     }
 };
 
@@ -84,6 +110,28 @@ TEST(IvpScipyOdeDopri5TestSuite, LinearOscillatorTestCase) {
     }
 }
 
+TEST(IvpScipyOdeDopri5TestSuite, OrbitEquationsProblemTestCase) {
+    double t0 = 0.0;
+    intptr_t dims[] = {
+        OrbitEquationsProblem::N,
+    };
+    OIFArrayF64 *y0 =
+        oif_init_array_f64_from_data(1, dims, OrbitEquationsProblem::y0);
+    OIFArrayF64 *y = oif_create_array_f64(1, dims);
+    ImplHandle implh = oif_init_impl("ivp", "scipy_ode_dopri5", 1, 0);
+
+    int status;
+    status = oif_ivp_set_initial_value(implh, y0, t0);
+    status = oif_ivp_set_rhs_fn(implh, OrbitEquationsProblem::rhs);
+
+    double t = 0.1;
+    auto t_span = {0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 2.0};
+    for (auto t : t_span) {
+        status = oif_ivp_integrate(implh, t, y);
+        EXPECT_NEAR(y->data[0], OrbitEquationsProblem::exact(t, 0), 1e-10);
+    }
+}
+
 TEST(IvpSundialsCvodeTestSuite, ScalarExpDecayTestCase) {
     double t0 = 0.0;
     intptr_t dims[] = {
@@ -125,5 +173,27 @@ TEST(IvpSundialsCvodeTestSuite, LinearOscillatorTestCase) {
     for (auto t : t_span) {
         status = oif_ivp_integrate(implh, t, y);
         EXPECT_NEAR(y->data[0], LinearOscillatorProblem::exact(t, 0), 1e-12);
+    }
+}
+
+TEST(IvpSundialsCvodeTestSuite, OrbitEquationsProblemTestCase) {
+    double t0 = 0.0;
+    intptr_t dims[] = {
+        OrbitEquationsProblem::N,
+    };
+    OIFArrayF64 *y0 =
+        oif_init_array_f64_from_data(1, dims, OrbitEquationsProblem::y0);
+    OIFArrayF64 *y = oif_create_array_f64(1, dims);
+    ImplHandle implh = oif_init_impl("ivp", "sundials_cvode", 1, 0);
+
+    int status;
+    status = oif_ivp_set_initial_value(implh, y0, t0);
+    status = oif_ivp_set_rhs_fn(implh, OrbitEquationsProblem::rhs);
+
+    double t = 0.1;
+    double t_span[] = {0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 2.0};
+    for (auto t : t_span) {
+        status = oif_ivp_integrate(implh, t, y);
+        EXPECT_NEAR(y->data[0], OrbitEquationsProblem::exact(t, 0), 1e-10);
     }
 }

--- a/tests/lang_c/test_ivp.cpp
+++ b/tests/lang_c/test_ivp.cpp
@@ -1,3 +1,4 @@
+#include "gtest/gtest.h"
 #include <cmath>
 #include <cstdio>
 
@@ -66,7 +67,10 @@ class OrbitEquationsProblem {
     }
 };
 
-TEST(IvpScipyOdeDopri5TestSuite, ScalarExpDecayTestCase) {
+struct IvpImplementationsFixture : public testing::TestWithParam<const char *> {
+};
+
+TEST_P(IvpImplementationsFixture, ScalarExpDecayTestCase) {
     double t0 = 0.0;
     intptr_t dims[] = {
         ScalarExpDecayProblem::N,
@@ -88,7 +92,7 @@ TEST(IvpScipyOdeDopri5TestSuite, ScalarExpDecayTestCase) {
     }
 }
 
-TEST(IvpScipyOdeDopri5TestSuite, LinearOscillatorTestCase) {
+TEST_P(IvpImplementationsFixture, LinearOscillatorTestCase) {
     double t0 = 0.0;
     intptr_t dims[] = {
         LinearOscillatorProblem::N,
@@ -110,7 +114,7 @@ TEST(IvpScipyOdeDopri5TestSuite, LinearOscillatorTestCase) {
     }
 }
 
-TEST(IvpScipyOdeDopri5TestSuite, OrbitEquationsProblemTestCase) {
+TEST_P(IvpImplementationsFixture, OrbitEquationsProblemTestCase) {
     double t0 = 0.0;
     intptr_t dims[] = {
         OrbitEquationsProblem::N,
@@ -132,68 +136,6 @@ TEST(IvpScipyOdeDopri5TestSuite, OrbitEquationsProblemTestCase) {
     }
 }
 
-TEST(IvpSundialsCvodeTestSuite, ScalarExpDecayTestCase) {
-    double t0 = 0.0;
-    intptr_t dims[] = {
-        ScalarExpDecayProblem::N,
-    };
-    OIFArrayF64 *y0 =
-        oif_init_array_f64_from_data(1, dims, ScalarExpDecayProblem::y0);
-    OIFArrayF64 *y = oif_create_array_f64(1, dims);
-    ImplHandle implh = oif_init_impl("ivp", "sundials_cvode", 1, 0);
-
-    int status;
-    status = oif_ivp_set_initial_value(implh, y0, t0);
-    status = oif_ivp_set_rhs_fn(implh, ScalarExpDecayProblem::rhs);
-
-    double t = 0.1;
-    auto t_span = {0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 2.0};
-    for (auto t : t_span) {
-        status = oif_ivp_integrate(implh, t, y);
-        EXPECT_NEAR(y->data[0], ScalarExpDecayProblem::exact(t, 0), 2e-15);
-    }
-}
-
-TEST(IvpSundialsCvodeTestSuite, LinearOscillatorTestCase) {
-    double t0 = 0.0;
-    intptr_t dims[] = {
-        LinearOscillatorProblem::N,
-    };
-    OIFArrayF64 *y0 =
-        oif_init_array_f64_from_data(1, dims, LinearOscillatorProblem::y0);
-    OIFArrayF64 *y = oif_create_array_f64(1, dims);
-    ImplHandle implh = oif_init_impl("ivp", "sundials_cvode", 1, 0);
-
-    int status;
-    status = oif_ivp_set_initial_value(implh, y0, t0);
-    status = oif_ivp_set_rhs_fn(implh, LinearOscillatorProblem::rhs);
-
-    double t = 0.1;
-    auto t_span = {0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 2.0};
-    for (auto t : t_span) {
-        status = oif_ivp_integrate(implh, t, y);
-        EXPECT_NEAR(y->data[0], LinearOscillatorProblem::exact(t, 0), 1e-12);
-    }
-}
-
-TEST(IvpSundialsCvodeTestSuite, OrbitEquationsProblemTestCase) {
-    double t0 = 0.0;
-    intptr_t dims[] = {
-        OrbitEquationsProblem::N,
-    };
-    OIFArrayF64 *y0 =
-        oif_init_array_f64_from_data(1, dims, OrbitEquationsProblem::y0);
-    OIFArrayF64 *y = oif_create_array_f64(1, dims);
-    ImplHandle implh = oif_init_impl("ivp", "sundials_cvode", 1, 0);
-
-    int status;
-    status = oif_ivp_set_initial_value(implh, y0, t0);
-    status = oif_ivp_set_rhs_fn(implh, OrbitEquationsProblem::rhs);
-
-    double t = 0.1;
-    double t_span[] = {0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 2.0};
-    for (auto t : t_span) {
-        status = oif_ivp_integrate(implh, t, y);
-        EXPECT_NEAR(y->data[0], OrbitEquationsProblem::exact(t, 0), 1e-10);
-    }
-}
+INSTANTIATE_TEST_SUITE_P(IvpImplementationsTests,
+                         IvpImplementationsFixture,
+                         testing::Values("scipy_ode_dopri5", "sundials_cvode"));

--- a/tests/lang_python/test_ivp.py
+++ b/tests/lang_python/test_ivp.py
@@ -23,6 +23,8 @@ class IVPProblem(ABC):
 
 
 class ScalarExpDecayProblem(IVPProblem):
+    """Problem :math:`y(t) = -y, y(0) = 1` with solution :math:`y(t)=exp(-t)`"""
+
     t0 = 0.0
     y0 = np.array([1.0])
 
@@ -34,6 +36,15 @@ class ScalarExpDecayProblem(IVPProblem):
 
 
 class LinearOscillatorProblem(IVPProblem):
+    r"""Linear second-order equation of non-decaying oscillator.
+
+    Second-order equation :math:`y''(t) + \omega^2 y(t) = 0` with given
+    :math:`y(0) = y_0` and :math:`y'(0) = y'_0`, and parameter :math:`\omega`.
+
+    Solution is given by::
+        y(t) = y_0 * \cos(\omega t) + y'_0 \frac{\sin(\omega t) / \omega}
+    """
+
     t0 = 0.0
     y0 = np.array([1.0, 0.5])
     omega = np.pi
@@ -58,6 +69,14 @@ class LinearOscillatorProblem(IVPProblem):
 
 
 class OrbitEquationsProblem(IVPProblem):
+    """System of differential equations that describes movement of two bodies.
+
+    This problem is problem 5 from Problem Class D from the paper:
+    Hull, T. E. et al. 1972. Comparing numerical methods for ordinary
+    differential equations. SIAM J. Numer. Anal., p. 620. doi:10.1137/0709052
+
+    """
+
     eps = 0.9
     t0 = 0.0
     y0 = np.array([1 - eps, 0.0, 0.0, np.sqrt((1 + eps) / (1 - eps))])

--- a/tests/lang_python/test_ivp.py
+++ b/tests/lang_python/test_ivp.py
@@ -55,7 +55,6 @@ class LinearOscillatorProblem(IVPProblem):
 
 class TestIVPViaScipyODEDopri5Implementation:
     def test_1(self, s, p):
-        p = ScalarExpDecayProblem()
         s.set_initial_value(p.y0, p.t0)
         s.set_rhs_fn(p.rhs)
 

--- a/tests/lang_python/test_ivp.py
+++ b/tests/lang_python/test_ivp.py
@@ -46,11 +46,14 @@ class LinearOscillatorProblem(IVPProblem):
         )
 
     def exact(self, t):
-        y_exact = (
-            self.y0[0] * np.cos(self.omega * t)
-            + self.y0[1] * np.sin(self.omega * t) / self.omega
+        return np.array(
+            [
+                self.y0[0] * np.cos(self.omega * t)
+                + self.y0[1] * np.sin(self.omega * t) / self.omega,
+                -self.y0[0] * self.omega * np.sin(self.omega * t)
+                + self.y0[1] * np.cos(self.omega * t),
+            ]
         )
-        return y_exact
 
 
 class TestIVPViaScipyODEDopri5Implementation:
@@ -61,10 +64,10 @@ class TestIVPViaScipyODEDopri5Implementation:
         t1 = p.t0 + 1
         times = np.linspace(p.t0, t1, num=11)
 
-        soln = [p.y0[0]]
+        soln = [p.y0]
         for t in times[1:]:
             s.integrate(t)
-            soln.append(s.y[0])
+            soln.append(s.y)
 
         npt.assert_allclose(soln[-1], p.exact(t1), rtol=1e-4)
 
@@ -75,10 +78,10 @@ class TestIVPViaScipyODEDopri5Implementation:
         t1 = p.t0 + 1
         times = np.linspace(p.t0, t1, num=11)
 
-        soln = [p.y0[0]]
+        soln = [p.y0]
         for t in times[1:]:
             s.integrate(t)
-            soln.append(s.y[0])
+            soln.append(s.y)
 
         npt.assert_allclose(soln[-1], p.exact(t1), rtol=1e-4)
 

--- a/tests/testutils.h
+++ b/tests/testutils.h
@@ -1,0 +1,55 @@
+#pragma once
+#include <cmath>
+#include <exception>
+
+/**
+ * Version of `sqrt` function with `constexpr` qualifier.
+ *
+ * The code uses Newton-Raphson procedure to find a root of a nonlinear
+ * function f(y) = 0 by truncated Taylor series.
+ * In this case, f(y) = y^2 - x, where `x` is a given constant.
+ *
+ * @param x Value, square root of which is to be computed
+ * @return Approximate value of the square root of `x`
+ */
+constexpr double constexpr_sqrt(double x) {
+    double tol = 1e-8;
+    double y = x / 2.0;
+    int k = 0;
+    const int max_iter = 50;
+
+    while ((std::abs(y * y - x) > tol) && (k < max_iter)) {
+        y = 0.5 * (y + x / y);
+        k += 1;
+    }
+
+    if (k > max_iter) {
+        throw std::exception();
+    }
+
+    return y;
+}
+
+/**
+ * Solve a nonlinear equation f(x) = 0 using the Newton-Raphson method.
+ * The implementation is simplistic so it expects also a derivative function
+ * `fprime` to be provided by user. Also, it works only for scalar functions
+ * `f: R -> R`.
+ */
+template <class F, class Fprime>
+double fsolve(F const &f, Fprime const &fprime) {
+    double x = 1.0;
+    double tol = 1e-15;
+    size_t k = 0;
+    const size_t max_iter = 50;
+
+    while (((std::abs(f(x))) > tol) && (k < max_iter)) {
+        x = x - f(x) / fprime(x);
+    }
+
+    if (k > max_iter) {
+        throw std::exception();
+    }
+
+    return x;
+}


### PR DESCRIPTION
This PR adds new problem - orbit equations - a set of two second-order equations (that result in a system of four first-order equations). Besides that, the code organization for IVP test suites is reorganized both in Python and C sides (C++ due to GTest).