### PR TITLE
[misc] Add isort to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,13 @@ repos:
           - id: cmake-format
 
     # Python source code
+    - repo: https://github.com/pycqa/isort
+      rev: 5.13.2
+      hooks:
+          - id: isort
+            name: isort (python)
+
+
     - repo: https://github.com/pycqa/flake8
       rev: 6.1.0
       hooks:

--- a/oif_impl/python/oif/impl/linsolve.py
+++ b/oif_impl/python/oif/impl/linsolve.py
@@ -1,4 +1,5 @@
 import abc
+
 import numpy as np
 
 


### PR DESCRIPTION
We could not use `isort` before (https://github.com/PyCQA/isort/issues/2228) as a `pre-commit` hook to sort Python imports.

However, as recommended in the above link, newer version (5.13.2 instead of 5.11.2) works successfully with `pre-commit`.

This PR adds a hook for `isort` so that it can be used for QA.