### PR TITLE
Improve dispatch API

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,6 +16,7 @@ Checks: >
     bugprone-signed-char-misuse,
     bugprone-sizeof-expression,
     bugprone-branch-clone,
+    misc-include-cleaner,
     -clang-analyzer-security.insecureAPI.*,
     -misc-no-recursion,
 

--- a/examples/call_ivp_from_python.py
+++ b/examples/call_ivp_from_python.py
@@ -29,7 +29,7 @@ def rhs(t, y, ydot):
 def main():
     args = _parse_args()
     impl = args.impl
-    print("Calling from Python an open interface for quadratic solver")
+    print("Calling from Python an open interface for initial-value problems")
     print(f"Implementation: {impl}")
     s = IVP(impl)
     t0 = 0.0

--- a/oif/dispatch.c
+++ b/oif/dispatch.c
@@ -174,15 +174,18 @@ load_interface_impl(const char *interface, const char *impl, size_t version_majo
         lib_handle = OIF_DISPATCH_HANDLES[dh];
     }
 
-    ImplInfo *(*load_backend_fn)(const char *, size_t, size_t);
-    load_backend_fn = dlsym(lib_handle, "load_backend");
+    ImplInfo *(*load_impl_fn)(const char *, size_t, size_t);
+    load_impl_fn = dlsym(lib_handle, "load_impl");
 
-    if (load_backend_fn == NULL) {
-        fprintf(stderr, "[dispatch] Could not load function %s: %s\n", "load_backend",
+    if (load_impl_fn == NULL) {
+        fprintf(stderr,
+                "[dispatch] Could not load function %s: %s\n",
+                "load_impl",
                 dlerror());
     }
 
-    ImplInfo *impl_info = load_backend_fn(impl_details, version_major, version_minor);
+    ImplInfo *impl_info =
+        load_impl_fn(impl_details, version_major, version_minor);
     if (impl_info == NULL) {
         fprintf(stderr, "[dispatch] Could not load implementation\n");
         return OIF_IMPL_INIT_ERROR;

--- a/oif/dispatch.c
+++ b/oif/dispatch.c
@@ -29,6 +29,7 @@ static const char *OIF_IMPL_ROOT_DIR;
  */
 void *OIF_DISPATCH_HANDLES[OIF_LANG_COUNT];
 
+// cppcheck-suppress unusedStructMember
 static HASHMAP(ImplHandle, ImplInfo) IMPL_MAP;
 
 static bool INITIALIZED_ = false;

--- a/oif/dispatch.c
+++ b/oif/dispatch.c
@@ -262,16 +262,17 @@ int call_interface_impl(ImplHandle implh,
     }
     void *lib_handle = OIF_DISPATCH_HANDLES[dh];
 
-    int (*run_interface_method_fn)(ImplInfo *, const char *, OIFArgs *, OIFArgs *);
-    run_interface_method_fn = dlsym(lib_handle, "run_interface_method");
-    if (run_interface_method_fn == NULL) {
+    int (*call_impl_fn)(
+        ImplInfo *, const char *, OIFArgs *, OIFArgs *);
+    call_impl_fn = dlsym(lib_handle, "call_impl");
+    if (call_impl_fn == NULL) {
         fprintf(stderr,
-                "[dispatch] Could not load function 'run_interface_method' "
+                "[dispatch] Could not load function 'call_impl' "
                 "for language id '%u'\n",
                 dh);
         return -1;
     }
-    status = run_interface_method_fn(impl_info, method, in_args, out_args);
+    status = call_impl_fn(impl_info, method, in_args, out_args);
 
     if (status) {
         fprintf(stderr,

--- a/oif/dispatch.c
+++ b/oif/dispatch.c
@@ -83,7 +83,8 @@ ImplHandle load_interface_impl(const char *interface,
     void *lib_handle = NULL;
     FILE *conf_file;
     char *buffer;
-    ImplHandle retval = -1;
+    /* One must be a pessimist, while programming in C. */
+    ImplHandle retval = OIF_IMPL_INIT_ERROR;
 
     char conf_filename[1024] = "";
     strcat(conf_filename, OIF_IMPL_ROOT_DIR);
@@ -244,9 +245,10 @@ unload_interface_impl(ImplHandle implh)
     return 0;
 }
 
-int
-call_interface_method(ImplHandle implh, const char *method, OIFArgs *args, OIFArgs *retvals)
-{
+int call_interface_impl(ImplHandle implh,
+                        const char *method,
+                        OIFArgs *in_args,
+                        OIFArgs *out_args) {
     int status;
 
     ImplInfo *impl_info = hashmap_get(&IMPL_MAP, &implh);
@@ -269,7 +271,7 @@ call_interface_method(ImplHandle implh, const char *method, OIFArgs *args, OIFAr
                 dh);
         return -1;
     }
-    status = run_interface_method_fn(impl_info, method, args, retvals);
+    status = run_interface_method_fn(impl_info, method, in_args, out_args);
 
     if (status) {
         fprintf(stderr,

--- a/oif/dispatch.c
+++ b/oif/dispatch.c
@@ -36,12 +36,11 @@ static bool INITIALIZED_ = false;
 
 static int IMPL_COUNTER_ = 1000;
 
-size_t hash_fn(const ImplHandle *key) {
+size_t
+hash_fn(const ImplHandle *key)
+{
     if (*key < 0) {
-        fprintf(
-            stderr,
-            "[dispatch] Was expecting a non-negative number\n"
-        );
+        fprintf(stderr, "[dispatch] Was expecting a non-negative number\n");
         exit(1);
     }
     return *key;
@@ -69,10 +68,10 @@ init_module_(void)
     return 0;
 }
 
-ImplHandle load_interface_impl(const char *interface,
-                               const char *impl,
-                               size_t version_major,
-                               size_t version_minor) {
+ImplHandle
+load_interface_impl(const char *interface, const char *impl, size_t version_major,
+                    size_t version_minor)
+{
     if (!INITIALIZED_) {
         int status = init_module_();
         if (status) {
@@ -130,7 +129,8 @@ ImplHandle load_interface_impl(const char *interface,
     if (buffer[len - 1] != '\n') {
         fprintf(stderr, "Backend name is longer than allocated buffer\n");
         goto cleanup;
-    } else {
+    }
+    else {
         // Trim the new line character.
         buffer[len - 1] = '\0';
     }
@@ -148,7 +148,8 @@ ImplHandle load_interface_impl(const char *interface,
     if (buffer[len - 1] != '\n') {
         fprintf(stderr, "[dispatch] Backend name is longer than allocated array\n");
         goto cleanup;
-    } else {
+    }
+    else {
         // Trim new line character.
         buffer[len - 1] = '\0';
     }
@@ -163,10 +164,9 @@ ImplHandle load_interface_impl(const char *interface,
     else if (strcmp(backend_name, "python") == 0) {
         dh = OIF_LANG_PYTHON;
         dispatch_lang_so = OIF_DISPATCH_PYTHON_SO;
-    } else {
-        fprintf(stderr,
-                "[dispatch] Implementation has unknown backend: '%s'\n",
-                backend_name);
+    }
+    else {
+        fprintf(stderr, "[dispatch] Implementation has unknown backend: '%s'\n", backend_name);
         goto cleanup;
     }
 
@@ -187,15 +187,11 @@ ImplHandle load_interface_impl(const char *interface,
     load_impl_fn = dlsym(lib_handle, "load_impl");
 
     if (load_impl_fn == NULL) {
-        fprintf(stderr,
-                "[dispatch] Could not load function %s: %s\n",
-                "load_impl",
-                dlerror());
+        fprintf(stderr, "[dispatch] Could not load function %s: %s\n", "load_impl", dlerror());
         goto cleanup;
     }
 
-    ImplInfo *impl_info =
-        load_impl_fn(impl_details, version_major, version_minor);
+    ImplInfo *impl_info = load_impl_fn(impl_details, version_major, version_minor);
     if (impl_info == NULL) {
         fprintf(stderr, "[dispatch] Could not load implementation\n");
         goto cleanup;
@@ -246,10 +242,9 @@ unload_interface_impl(ImplHandle implh)
     return 0;
 }
 
-int call_interface_impl(ImplHandle implh,
-                        const char *method,
-                        OIFArgs *in_args,
-                        OIFArgs *out_args) {
+int
+call_interface_impl(ImplHandle implh, const char *method, OIFArgs *in_args, OIFArgs *out_args)
+{
     int status;
 
     ImplInfo *impl_info = hashmap_get(&IMPL_MAP, &implh);
@@ -263,8 +258,7 @@ int call_interface_impl(ImplHandle implh,
     }
     void *lib_handle = OIF_DISPATCH_HANDLES[dh];
 
-    int (*call_impl_fn)(
-        ImplInfo *, const char *, OIFArgs *, OIFArgs *);
+    int (*call_impl_fn)(ImplInfo *, const char *, OIFArgs *, OIFArgs *);
     call_impl_fn = dlsym(lib_handle, "call_impl");
     if (call_impl_fn == NULL) {
         fprintf(stderr,

--- a/oif/include/oif/api.h
+++ b/oif/include/oif/api.h
@@ -39,6 +39,6 @@ typedef struct {
 } OIFCallback;
 
 enum {
-    OIF_ERROR = 101,
-    OIF_IMPL_INIT_ERROR = 102,
+    OIF_ERROR = -1,
+    OIF_IMPL_INIT_ERROR = -2,
 };

--- a/oif/include/oif/dispatch.h
+++ b/oif/include/oif/dispatch.h
@@ -30,6 +30,16 @@ load_interface_impl(const char *interface, const char *impl, size_t version_majo
 int
 unload_interface_impl(ImplHandle implh);
 
-int
-call_interface_method(ImplHandle implh, const char *method, OIFArgs *args, OIFArgs *retvals);
+/**
+ * Call implementation of an interface.
+ * @param implh Implementat handle that identifies the implementation
+ * @param method Name of the method (function) to invoke
+ * @param in_args Array of input arguments
+ * @param out_args Array of output arguments
+ * @return status code that signals about an error if non-zero
+ */
+int call_interface_impl(ImplHandle implh,
+                        const char *method,
+                        OIFArgs *in_args,
+                        OIFArgs *out_args);
 #endif

--- a/oif/include/oif/dispatch.h
+++ b/oif/include/oif/dispatch.h
@@ -38,8 +38,6 @@ unload_interface_impl(ImplHandle implh);
  * @param out_args Array of output arguments
  * @return status code that signals about an error if non-zero
  */
-int call_interface_impl(ImplHandle implh,
-                        const char *method,
-                        OIFArgs *in_args,
-                        OIFArgs *out_args);
+int
+call_interface_impl(ImplHandle implh, const char *method, OIFArgs *in_args, OIFArgs *out_args);
 #endif

--- a/oif/include/oif/dispatch_api.h
+++ b/oif/include/oif/dispatch_api.h
@@ -27,14 +27,11 @@ typedef struct {
     DispatchHandle dh;
 } ImplInfo;
 
-ImplInfo *load_impl(const char *impl_details,
-                    size_t version_major,
-                    size_t version_minor);
+ImplInfo *
+load_impl(const char *impl_details, size_t version_major, size_t version_minor);
 
 int
 unload_impl(ImplInfo *impl_info);
 
-int call_impl(ImplInfo *impl_info,
-              const char *method,
-              OIFArgs *in_args,
-              OIFArgs *out_args);
+int
+call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *out_args);

--- a/oif/include/oif/dispatch_api.h
+++ b/oif/include/oif/dispatch_api.h
@@ -27,12 +27,14 @@ typedef struct {
     DispatchHandle dh;
 } ImplInfo;
 
-ImplInfo *
-load_backend(const char *impl_details, size_t version_major, size_t version_minor);
+ImplInfo *load_impl(const char *impl_details,
+                    size_t version_major,
+                    size_t version_minor);
 
 int
 unload_impl(ImplInfo *impl_info);
 
-int
-run_interface_method(ImplInfo *impl_info, const char *method, OIFArgs *in_args,
-                     OIFArgs *out_args);
+int call_impl(ImplInfo *impl_info,
+              const char *method,
+              OIFArgs *in_args,
+              OIFArgs *out_args);

--- a/oif/interfaces/c/src/ivp.c
+++ b/oif/interfaces/c/src/ivp.c
@@ -26,7 +26,8 @@ oif_ivp_set_rhs_fn(ImplHandle implh, oif_ivp_rhs_fn_t rhs)
         .arg_values = out_arg_values,
     };
 
-    int status = call_interface_method(implh, "set_rhs_fn", &in_args, &out_args);
+    int status =
+        call_interface_impl(implh, "set_rhs_fn", &in_args, &out_args);
 
     return status;
 }
@@ -50,7 +51,8 @@ oif_ivp_set_initial_value(ImplHandle implh, OIFArrayF64 *y0, double t0)
         .arg_values = out_arg_values,
     };
 
-    int status = call_interface_method(implh, "set_initial_value", &in_args, &out_args);
+    int status =
+        call_interface_impl(implh, "set_initial_value", &in_args, &out_args);
 
     return status;
 }
@@ -74,7 +76,7 @@ oif_ivp_integrate(ImplHandle implh, double t, OIFArrayF64 *y)
         .arg_values = out_arg_values,
     };
 
-    int status = call_interface_method(implh, "integrate", &in_args, &out_args);
+    int status = call_interface_impl(implh, "integrate", &in_args, &out_args);
 
     return status;
 }

--- a/oif/interfaces/c/src/ivp.c
+++ b/oif/interfaces/c/src/ivp.c
@@ -26,8 +26,7 @@ oif_ivp_set_rhs_fn(ImplHandle implh, oif_ivp_rhs_fn_t rhs)
         .arg_values = out_arg_values,
     };
 
-    int status =
-        call_interface_impl(implh, "set_rhs_fn", &in_args, &out_args);
+    int status = call_interface_impl(implh, "set_rhs_fn", &in_args, &out_args);
 
     return status;
 }
@@ -51,8 +50,7 @@ oif_ivp_set_initial_value(ImplHandle implh, OIFArrayF64 *y0, double t0)
         .arg_values = out_arg_values,
     };
 
-    int status =
-        call_interface_impl(implh, "set_initial_value", &in_args, &out_args);
+    int status = call_interface_impl(implh, "set_initial_value", &in_args, &out_args);
 
     return status;
 }

--- a/oif/interfaces/c/src/linsolve.c
+++ b/oif/interfaces/c/src/linsolve.c
@@ -23,7 +23,7 @@ oif_solve_linear_system(ImplHandle implh, OIFArrayF64 *A, OIFArrayF64 *b, OIFArr
         .arg_values = out_arg_values,
     };
 
-    int status = call_interface_method(implh, "solve_lin", &in_args, &out_args);
+    int status = call_interface_impl(implh, "solve_lin", &in_args, &out_args);
 
     return status;
 }

--- a/oif/interfaces/c/src/qeq.c
+++ b/oif/interfaces/c/src/qeq.c
@@ -23,7 +23,7 @@ oif_solve_qeq(ImplHandle implh, double a, double b, double c, OIFArrayF64 *roots
         .arg_values = out_arg_values,
     };
 
-    int status = call_interface_method(implh, "solve_qeq", &in_args, &out_args);
+    int status = call_interface_impl(implh, "solve_qeq", &in_args, &out_args);
 
     return status;
 }

--- a/oif/interfaces/python/oif/interfaces/ivp.py
+++ b/oif/interfaces/python/oif/interfaces/ivp.py
@@ -45,4 +45,5 @@ class IVP:
         self._binding.call("print_stats", (), ())
 
     def __del__(self):
-        unload_impl(self._binding)
+        if hasattr(self, "_binding"):
+            unload_impl(self._binding)

--- a/oif/interfaces/python/oif/interfaces/linear_solver.py
+++ b/oif/interfaces/python/oif/interfaces/linear_solver.py
@@ -12,4 +12,5 @@ class LinearSolver:
         return result
 
     def __del__(self):
-        unload_impl(self._binding)
+        if hasattr(self, "_binding"):
+            unload_impl(self._binding)

--- a/oif/interfaces/python/oif/interfaces/qeq_solver.py
+++ b/oif/interfaces/python/oif/interfaces/qeq_solver.py
@@ -12,4 +12,5 @@ class QeqSolver:
         return result
 
     def __del__(self):
-        unload_impl(self._binding)
+        if hasattr(self, "_binding"):
+            unload_impl(self._binding)

--- a/oif/lang_python/oif/core.py
+++ b/oif/lang_python/oif/core.py
@@ -223,9 +223,9 @@ class OIFPyBinding:
         )
         out_packed = OIFArgs(num_out_args, out_arg_types_ctypes, out_arg_values_ctypes)
 
-        call_interface_method = _wrap_c_function(
+        call_interface_impl = _wrap_c_function(
             _lib_dispatch,
-            "call_interface_method",
+            "call_interface_impl",
             ctypes.c_int,
             [
                 ctypes.c_int,
@@ -234,7 +234,7 @@ class OIFPyBinding:
                 ctypes.POINTER(OIFArgs),
             ],
         )
-        status = call_interface_method(
+        status = call_interface_impl(
             self.implh,
             method.encode(),
             ctypes.byref(in_args_packed),

--- a/oif/lang_python/oif/core.py
+++ b/oif/lang_python/oif/core.py
@@ -223,7 +223,7 @@ class OIFPyBinding:
         )
         out_packed = OIFArgs(num_out_args, out_arg_types_ctypes, out_arg_values_ctypes)
 
-        call_interface_method = wrap_c_function(
+        call_interface_method = _wrap_c_function(
             _lib_dispatch,
             "call_interface_method",
             ctypes.c_int,
@@ -248,7 +248,7 @@ class OIFPyBinding:
 
 
 def init_impl(interface: str, impl: str, major: UInt, minor: UInt):
-    load_interface_impl = wrap_c_function(
+    load_interface_impl = _wrap_c_function(
         _lib_dispatch,
         "load_interface_impl",
         ctypes.c_int,
@@ -265,7 +265,7 @@ def init_impl(interface: str, impl: str, major: UInt, minor: UInt):
 
 
 def unload_impl(binding: OIFPyBinding):
-    unload_interface_impl = wrap_c_function(
+    unload_interface_impl = _wrap_c_function(
         _lib_dispatch,
         "unload_interface_impl",
         ctypes.c_int,
@@ -279,7 +279,7 @@ def unload_impl(binding: OIFPyBinding):
         )
 
 
-def wrap_c_function(lib, funcname, restype, argtypes):
+def _wrap_c_function(lib, funcname, restype, argtypes):
     if isinstance(argtypes, list):
         if len(argtypes) == 1:
             assert argtypes[0] is not None, "For func(void) pass [] or None, not [None]"

--- a/oif/lang_python/oif/core.py
+++ b/oif/lang_python/oif/core.py
@@ -256,7 +256,11 @@ def init_impl(interface: str, impl: str, major: UInt, minor: UInt):
     )
     implh = load_interface_impl(interface.encode(), impl.encode(), major, minor)
     if implh < 0:
-        raise RuntimeError("Cannot initialize backend")
+        raise RuntimeError(
+            "Error occurred "
+            f"during initialization of the implementation '{impl}' "
+            f"for the interface '{interface}'"
+        )
     return OIFPyBinding(implh, interface, impl)
 
 

--- a/oif_impl/c/dispatch_c.c
+++ b/oif_impl/c/dispatch_c.c
@@ -68,10 +68,10 @@ unload_impl(ImplInfo *impl_info_)
     return 0;
 }
 
-int
-run_interface_method(ImplInfo *impl_info, const char *method, OIFArgs *in_args,
-                     OIFArgs *out_args)
-{
+int call_impl(ImplInfo *impl_info,
+              const char *method,
+              OIFArgs *in_args,
+              OIFArgs *out_args) {
     if (impl_info->dh != OIF_LANG_C) {
         fprintf(stderr, "[dispatch_c] Provided implementation is not implemented in C\n");
         return -1;

--- a/oif_impl/c/dispatch_c.c
+++ b/oif_impl/c/dispatch_c.c
@@ -16,9 +16,9 @@ typedef struct {
 
 static int IMPL_COUNTER = 0;
 
-ImplInfo *
-load_backend(const char *impl_details, size_t version_major, size_t version_minor)
-{
+ImplInfo *load_impl(const char *impl_details,
+                    size_t version_major,
+                    size_t version_minor) {
     // For C implementations, `impl_details` must contain the name
     // of the shared library with the methods implemented as functions.
     void *impl_lib = dlopen(impl_details, RTLD_LOCAL | RTLD_LAZY);

--- a/oif_impl/c/dispatch_c.c
+++ b/oif_impl/c/dispatch_c.c
@@ -16,9 +16,9 @@ typedef struct {
 
 static int IMPL_COUNTER = 0;
 
-ImplInfo *load_impl(const char *impl_details,
-                    size_t version_major,
-                    size_t version_minor) {
+ImplInfo *
+load_impl(const char *impl_details, size_t version_major, size_t version_minor)
+{
     // For C implementations, `impl_details` must contain the name
     // of the shared library with the methods implemented as functions.
     void *impl_lib = dlopen(impl_details, RTLD_LOCAL | RTLD_LAZY);
@@ -68,10 +68,9 @@ unload_impl(ImplInfo *impl_info_)
     return 0;
 }
 
-int call_impl(ImplInfo *impl_info,
-              const char *method,
-              OIFArgs *in_args,
-              OIFArgs *out_args) {
+int
+call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *out_args)
+{
     if (impl_info->dh != OIF_LANG_C) {
         fprintf(stderr, "[dispatch_c] Provided implementation is not implemented in C\n");
         return -1;

--- a/oif_impl/python/dispatch_python.c
+++ b/oif_impl/python/dispatch_python.c
@@ -70,9 +70,9 @@ convert_oif_callback(OIFCallback *p)
     return obj;
 }
 
-ImplInfo *
-load_backend(const char *impl_details, size_t version_major, size_t version_minor)
-{
+ImplInfo *load_impl(const char *impl_details,
+                       size_t version_major,
+                       size_t version_minor) {
     if (Py_IsInitialized()) {
         fprintf(stderr, "[backend_python] Backend is already initialized\n");
     }

--- a/oif_impl/python/dispatch_python.c
+++ b/oif_impl/python/dispatch_python.c
@@ -70,9 +70,9 @@ convert_oif_callback(OIFCallback *p)
     return obj;
 }
 
-ImplInfo *load_impl(const char *impl_details,
-                       size_t version_major,
-                       size_t version_minor) {
+ImplInfo *
+load_impl(const char *impl_details, size_t version_major, size_t version_minor)
+{
     if (Py_IsInitialized()) {
         fprintf(stderr, "[backend_python] Backend is already initialized\n");
     }
@@ -178,10 +178,9 @@ ImplInfo *load_impl(const char *impl_details,
     return (ImplInfo *)impl_info;
 }
 
-int call_impl(ImplInfo *impl_info,
-              const char *method,
-              OIFArgs *in_args,
-              OIFArgs *out_args) {
+int
+call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *out_args)
+{
     if (impl_info->dh != OIF_LANG_PYTHON) {
         fprintf(stderr, "[dispatch_python] Provided implementation is not in Python\n");
         return -1;

--- a/oif_impl/python/dispatch_python.c
+++ b/oif_impl/python/dispatch_python.c
@@ -178,10 +178,10 @@ ImplInfo *load_impl(const char *impl_details,
     return (ImplInfo *)impl_info;
 }
 
-int
-run_interface_method(ImplInfo *impl_info, const char *method, OIFArgs *in_args,
-                     OIFArgs *out_args)
-{
+int call_impl(ImplInfo *impl_info,
+              const char *method,
+              OIFArgs *in_args,
+              OIFArgs *out_args) {
     if (impl_info->dh != OIF_LANG_PYTHON) {
         fprintf(stderr, "[dispatch_python] Provided implementation is not in Python\n");
         return -1;


### PR DESCRIPTION
This PR

- fixes warnings in `dispatch.c` found by `clang-tidy` and `cppcheck`
- Improves dispatch API by renaming `load_backend` to `load_impl`, `call_interface_method` to `call_interface_impl`, `run_interface_method` to `call_impl`.

So now:
- `dispatch.c` (liboif) has functions `load_interface_impl`, `unload_interface_impl`, `call_interface_impl`
- Each language-specific dispatch implements functions `load_impl`, `unload_impl`, `call_impl`.

Therefore, the API becomes more logical and easier to use.