### PR TITLE
Implement `user_data` argument for right-hand side callbacks for `IVP` interface

### DIFF
--- a/examples/call_ivp_from_c.c
+++ b/examples/call_ivp_from_c.c
@@ -27,9 +27,11 @@ parse_impl(int argc, char *argv[])
 }
 
 int
-rhs(double t, OIFArrayF64 *y, OIFArrayF64 *rhs_out)
+rhs(double t, OIFArrayF64 *y, OIFArrayF64 *rhs_out, void *user_data)
 {
-    int size = y->dimensions[0];
+    (void) t; /* Unused */
+    (void) user_data;  /* Unused */
+    intptr_t size = y->dimensions[0];
     for (int i = 0; i < size; ++i) {
         rhs_out->data[i] = -y->data[i];
     }

--- a/examples/call_ivp_from_c.c
+++ b/examples/call_ivp_from_c.c
@@ -29,8 +29,8 @@ parse_impl(int argc, char *argv[])
 int
 rhs(double t, OIFArrayF64 *y, OIFArrayF64 *rhs_out, void *user_data)
 {
-    (void) t; /* Unused */
-    (void) user_data;  /* Unused */
+    (void)t;         /* Unused */
+    (void)user_data; /* Unused */
     intptr_t size = y->dimensions[0];
     for (int i = 0; i < size; ++i) {
         rhs_out->data[i] = -y->data[i];

--- a/examples/call_ivp_from_python.py
+++ b/examples/call_ivp_from_python.py
@@ -22,7 +22,7 @@ def _parse_args():
     return Args(**vars(args))
 
 
-def rhs(t, y, ydot):
+def rhs(t, y, ydot, user_data):
     ydot[:] = -y
 
 

--- a/oif/include/oif/api.h
+++ b/oif/include/oif/api.h
@@ -16,7 +16,7 @@ typedef enum {
     OIF_FLOAT64 = 3,
     // OIF_FLOAT32_P = 4,
     OIF_ARRAY_F64 = 5,
-    OIF_VOID_P = 6,
+    OIF_USER_DATA = 6,
     OIF_CALLBACK = 7,
 } OIFArgType;
 
@@ -51,6 +51,18 @@ typedef struct {
     void *fn_p_py;  // Function pointer in Python
     void *fn_p_c;   // Function pointer in C
 } OIFCallback;
+
+/**
+ * Structure that holds a pointer to user data in one of its fields
+ * depending on the language.
+ * All the fields can be NULL except the field `src` that must be set
+ * to the constant of the language of the data origin.
+ */
+typedef struct {
+    int src;        // Language of the data origin (one of `OIF_LANG_*` constants)
+    void *c;        // Pointer to data in C
+    void *py;       // Pointer to `PyObject` that holds the data in Python
+} OIFUserData;
 
 enum {
     OIF_ERROR = -1,

--- a/oif/include/oif/api.h
+++ b/oif/include/oif/api.h
@@ -59,9 +59,9 @@ typedef struct {
  * to the constant of the language of the data origin.
  */
 typedef struct {
-    int src;        // Language of the data origin (one of `OIF_LANG_*` constants)
-    void *c;        // Pointer to data in C
-    void *py;       // Pointer to `PyObject` that holds the data in Python
+    int src;   // Language of the data origin (one of `OIF_LANG_*` constants)
+    void *c;   // Pointer to data in C
+    void *py;  // Pointer to `PyObject` that holds the data in Python
 } OIFUserData;
 
 enum {

--- a/oif/include/oif/api.h
+++ b/oif/include/oif/api.h
@@ -16,8 +16,9 @@ typedef enum {
     OIF_FLOAT64 = 3,
     // OIF_FLOAT32_P = 4,
     OIF_ARRAY_F64 = 5,
-    OIF_USER_DATA = 6,
+    OIF_STR = 6,
     OIF_CALLBACK = 7,
+    OIF_USER_DATA = 8,
 } OIFArgType;
 
 enum {

--- a/oif/include/oif/api.h
+++ b/oif/include/oif/api.h
@@ -20,6 +20,15 @@ typedef enum {
     OIF_CALLBACK = 7,
 } OIFArgType;
 
+enum {
+    OIF_LANG_C = 1,
+    OIF_LANG_CXX = 2,
+    OIF_LANG_PYTHON = 3,
+    OIF_LANG_JULIA = 4,
+    OIF_LANG_R = 5,
+    OIF_LANG_COUNT = 6,
+};
+
 typedef struct {
     size_t num_args;
     OIFArgType *arg_types;

--- a/oif/include/oif/api.h
+++ b/oif/include/oif/api.h
@@ -7,11 +7,11 @@ typedef int ImplHandle;
 
 typedef enum {
     OIF_INT = 1,
-    OIF_FLOAT32 = 2,
+    // OIF_FLOAT32 = 2,
     OIF_FLOAT64 = 3,
-    OIF_FLOAT32_P = 4,
+    // OIF_FLOAT32_P = 4,
     OIF_ARRAY_F64 = 5,
-    OIF_STR = 6,
+    OIF_VOID_P = 6,
     OIF_CALLBACK = 7,
 } OIFArgType;
 

--- a/oif/include/oif/api.h
+++ b/oif/include/oif/api.h
@@ -1,4 +1,9 @@
 #pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -42,3 +47,7 @@ enum {
     OIF_ERROR = -1,
     OIF_IMPL_INIT_ERROR = -2,
 };
+
+#ifdef __cplusplus
+}
+#endif

--- a/oif/include/oif/c_bindings.h
+++ b/oif/include/oif/c_bindings.h
@@ -1,4 +1,9 @@
 #pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <oif/api.h>
 
 /**
@@ -30,3 +35,7 @@ oif_print_matrix(OIFArrayF64 *mat);
 
 void
 oif_print_vector(OIFArrayF64 *vec);
+
+#ifdef __cplusplus
+}
+#endif

--- a/oif/include/oif/dispatch_api.h
+++ b/oif/include/oif/dispatch_api.h
@@ -4,15 +4,6 @@
  */
 #include <oif/api.h>
 
-enum {
-    OIF_LANG_C = 1,
-    OIF_LANG_CXX = 2,
-    OIF_LANG_PYTHON = 3,
-    OIF_LANG_JULIA = 4,
-    OIF_LANG_R = 5,
-    OIF_LANG_COUNT = 6,
-};
-
 // Identifier for the language-specific dispatch library (C, Python, etc.).
 typedef unsigned int DispatchHandle;
 

--- a/oif/interfaces/c/include/oif/interfaces/ivp.h
+++ b/oif/interfaces/c/include/oif/interfaces/ivp.h
@@ -36,4 +36,3 @@ oif_ivp_integrate(ImplHandle implh, double t, OIFArrayF64 *y);
 #ifdef __cplusplus
 }
 #endif
-

--- a/oif/interfaces/c/include/oif/interfaces/ivp.h
+++ b/oif/interfaces/c/include/oif/interfaces/ivp.h
@@ -2,7 +2,7 @@
 
 #include <oif/api.h>
 
-typedef int (*oif_ivp_rhs_fn_t)(double, OIFArrayF64 *y, OIFArrayF64 *y_dot);
+typedef int (*oif_ivp_rhs_fn_t)(double, OIFArrayF64 *y, OIFArrayF64 *ydot, void *user_data);
 
 /**
  * Set right hand side of the system of ordinary differential equations.
@@ -15,6 +15,13 @@ oif_ivp_set_rhs_fn(ImplHandle implh, oif_ivp_rhs_fn_t rhs);
  */
 int
 oif_ivp_set_initial_value(ImplHandle implh, OIFArrayF64 *y0, double t0);
+
+/**
+ * Set user data that can be used to pass additional information
+ * to the right-hand side function.
+ */
+int
+oif_ivp_set_user_data(ImplHandle implh, void *user_data);
 
 /**
  * Integrate to time `t` and write the solution to `y`.

--- a/oif/interfaces/c/include/oif/interfaces/ivp.h
+++ b/oif/interfaces/c/include/oif/interfaces/ivp.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <oif/api.h>
 
 typedef int (*oif_ivp_rhs_fn_t)(double, OIFArrayF64 *y, OIFArrayF64 *ydot, void *user_data);
@@ -28,3 +32,8 @@ oif_ivp_set_user_data(ImplHandle implh, void *user_data);
  */
 int
 oif_ivp_integrate(ImplHandle implh, double t, OIFArrayF64 *y);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/oif/interfaces/c/include/oif/interfaces/linsolve.h
+++ b/oif/interfaces/c/include/oif/interfaces/linsolve.h
@@ -15,4 +15,3 @@ oif_solve_linear_system(ImplHandle implh, OIFArrayF64 *A, OIFArrayF64 *b, OIFArr
 #ifdef __cplusplus
 }
 #endif
-

--- a/oif/interfaces/c/include/oif/interfaces/linsolve.h
+++ b/oif/interfaces/c/include/oif/interfaces/linsolve.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <oif/api.h>
 
 /**
@@ -7,3 +11,8 @@
  */
 int
 oif_solve_linear_system(ImplHandle implh, OIFArrayF64 *A, OIFArrayF64 *b, OIFArrayF64 *x);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/oif/interfaces/c/include/oif/interfaces/qeq.h
+++ b/oif/interfaces/c/include/oif/interfaces/qeq.h
@@ -1,6 +1,15 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <oif/api.h>
 
 int
 oif_solve_qeq(ImplHandle implh, double a, double b, double c, OIFArrayF64 *roots);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/oif/interfaces/c/include/oif/interfaces/qeq.h
+++ b/oif/interfaces/c/include/oif/interfaces/qeq.h
@@ -12,4 +12,3 @@ oif_solve_qeq(ImplHandle implh, double a, double b, double c, OIFArrayF64 *roots
 #ifdef __cplusplus
 }
 #endif
-

--- a/oif/interfaces/c/src/ivp.c
+++ b/oif/interfaces/c/src/ivp.c
@@ -55,7 +55,8 @@ oif_ivp_set_initial_value(ImplHandle implh, OIFArrayF64 *y0, double t0)
     return status;
 }
 
-int oif_ivp_set_user_data(ImplHandle implh, void *user_data)
+int
+oif_ivp_set_user_data(ImplHandle implh, void *user_data)
 {
     OIFArgType in_arg_types[] = {OIF_VOID_P};
     void *in_arg_values[] = {&user_data};

--- a/oif/interfaces/c/src/ivp.c
+++ b/oif/interfaces/c/src/ivp.c
@@ -55,6 +55,30 @@ oif_ivp_set_initial_value(ImplHandle implh, OIFArrayF64 *y0, double t0)
     return status;
 }
 
+int oif_ivp_set_user_data(ImplHandle implh, void *user_data)
+{
+    OIFArgType in_arg_types[] = {OIF_VOID_P};
+    void *in_arg_values[] = {&user_data};
+    size_t n = sizeof(in_arg_values) / sizeof(in_arg_values[0]);
+    OIFArgs in_args = {
+        .num_args = n,
+        .arg_types = in_arg_types,
+        .arg_values = in_arg_values,
+    };
+
+    OIFArgType out_arg_types[] = {};
+    void *out_arg_values[] = {};
+    size_t num_out_args = sizeof(out_arg_values) / sizeof(out_arg_values[0]);
+    OIFArgs out_args = {
+        .num_args = num_out_args,
+        .arg_types = out_arg_types,
+        .arg_values = out_arg_values,
+    };
+
+    int status = call_interface_impl(implh, "set_user_data", &in_args, &out_args);
+    return status;
+}
+
 int
 oif_ivp_integrate(ImplHandle implh, double t, OIFArrayF64 *y)
 {

--- a/oif/interfaces/c/src/ivp.c
+++ b/oif/interfaces/c/src/ivp.c
@@ -58,8 +58,12 @@ oif_ivp_set_initial_value(ImplHandle implh, OIFArrayF64 *y0, double t0)
 int
 oif_ivp_set_user_data(ImplHandle implh, void *user_data)
 {
-    OIFArgType in_arg_types[] = {OIF_VOID_P};
-    void *in_arg_values[] = {&user_data};
+    OIFArgType in_arg_types[] = {OIF_USER_DATA};
+    OIFUserData oif_user_data = {
+        .src = OIF_LANG_C,
+        .c = user_data,
+    };
+    void *in_arg_values[] = {&oif_user_data};
     size_t n = sizeof(in_arg_values) / sizeof(in_arg_values[0]);
     OIFArgs in_args = {
         .num_args = n,

--- a/oif/interfaces/python/oif/interfaces/ivp.py
+++ b/oif/interfaces/python/oif/interfaces/ivp.py
@@ -35,6 +35,9 @@ class IVP:
         )
         self._binding.call("set_rhs_fn", (self.wrapper,), ())
 
+    def set_user_data(self, user_data: object):
+        self._binding.call("set_user_data", (user_data,), ())
+
     def set_tolerances(self, rtol: float, atol: float):
         self._binding.call("set_tolerances", (rtol, atol), ())
 

--- a/oif/interfaces/python/oif/interfaces/ivp.py
+++ b/oif/interfaces/python/oif/interfaces/ivp.py
@@ -3,9 +3,11 @@ from oif.core import (
     OIF_ARRAY_F64,
     OIF_FLOAT64,
     OIF_INT,
+    OIF_USER_DATA,
     OIFPyBinding,
     init_impl,
     make_oif_callback,
+    make_oif_user_data,
     unload_impl,
 )
 
@@ -31,12 +33,13 @@ class IVP:
             raise RuntimeError("'set_initial_value' must be called before 'set_rhs_fn'")
 
         self.wrapper = make_oif_callback(
-            rhs_fn, (OIF_FLOAT64, OIF_ARRAY_F64, OIF_ARRAY_F64), OIF_INT
+            rhs_fn, (OIF_FLOAT64, OIF_ARRAY_F64, OIF_ARRAY_F64, OIF_USER_DATA), OIF_INT
         )
         self._binding.call("set_rhs_fn", (self.wrapper,), ())
 
     def set_user_data(self, user_data: object):
-        self._binding.call("set_user_data", (user_data,), ())
+        self.user_data = make_oif_user_data(user_data)
+        self._binding.call("set_user_data", (self.user_data,), ())
 
     def set_tolerances(self, rtol: float, atol: float):
         self._binding.call("set_tolerances", (rtol, atol), ())

--- a/oif/lang_python/oif/core.py
+++ b/oif/lang_python/oif/core.py
@@ -14,6 +14,8 @@ OIF_FLOAT32_P = 4
 OIF_ARRAY_F64 = 5
 OIF_STR = 6
 OIF_CALLBACK = 7
+OIF_USER_DATA = 8
+
 
 OIF_LANG_C = 1
 OIF_LANG_CXX = 2
@@ -54,13 +56,12 @@ class OIFCallback(ctypes.Structure):
     ]
 
 
-# class OIFCallback(ctypes.Structure):
-#     _fields_ = [
-#         ("fn", ctypes.CFUNCTYPE),
-#         ("num_args", ctypes.c_size_t),
-#         ("argtypes", ctypes.POINTER(OIFArgType)),
-#         ("restype", OIFArgType),
-#     ]
+class OIFUserData(ctypes.Structure):
+    _fields_ = [
+        ("src", ctypes.c_int),
+        ("c", ctypes.c_void_p),
+        ("py", ctypes.c_void_p),
+    ]
 
 
 def make_oif_callback(

--- a/oif_impl/c/dispatch_c.c
+++ b/oif_impl/c/dispatch_c.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <dlfcn.h>
 #include <ffi.h>
 #include <stdio.h>

--- a/oif_impl/c/dispatch_c.c
+++ b/oif_impl/c/dispatch_c.c
@@ -138,8 +138,20 @@ call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *ou
         else if (in_args->arg_types[i] == OIF_ARRAY_F64) {
             arg_types[i] = &ffi_type_pointer;
         }
-        else if (in_args->arg_types[i] == OIF_VOID_P) {
+        else if (in_args->arg_types[i] == OIF_USER_DATA) {
+            arg_types[i] = NULL;
             arg_types[i] = &ffi_type_pointer;
+            OIFUserData *user_data = (OIFUserData *) in_args->arg_values[i];
+            if (user_data->src == OIF_LANG_C) {
+                in_args->arg_values[i] = &user_data->c;
+            }
+            else if (user_data->src == OIF_LANG_PYTHON) {
+                in_args->arg_values[i] = &user_data->py;
+            }
+            else {
+                fprintf(stderr, "[dispatch_c] Cannot handle OIFUserData because of the unsupported language.\n");
+                goto cleanup;
+            }
         }
         else if (in_args->arg_types[i] == OIF_CALLBACK) {
             arg_types[i] = &ffi_type_pointer;

--- a/oif_impl/c/dispatch_c.c
+++ b/oif_impl/c/dispatch_c.c
@@ -42,8 +42,8 @@ static int IMPL_COUNTER = 0;
 ImplInfo *
 load_impl(const char *impl_details, size_t version_major, size_t version_minor)
 {
-    (void) version_major;
-    (void) version_minor;
+    (void)version_major;
+    (void)version_minor;
     // For C implementations, `impl_details` must contain the name
     // of the shared library with the methods implemented as functions.
     void *impl_lib = dlopen(impl_details, RTLD_LOCAL | RTLD_LAZY);
@@ -118,7 +118,7 @@ call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *ou
 
     size_t num_in_args = in_args->num_args;
     size_t num_out_args = out_args->num_args;
-    unsigned int num_total_args = (unsigned int) (num_in_args + num_out_args);
+    unsigned int num_total_args = (unsigned int)(num_in_args + num_out_args);
 
     arg_types = malloc(num_total_args * sizeof(ffi_type *));
     if (arg_types == NULL) {
@@ -142,7 +142,7 @@ call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *ou
         else if (in_args->arg_types[i] == OIF_USER_DATA) {
             arg_types[i] = NULL;
             arg_types[i] = &ffi_type_pointer;
-            OIFUserData *user_data = (OIFUserData *) in_args->arg_values[i];
+            OIFUserData *user_data = (OIFUserData *)in_args->arg_values[i];
             if (user_data->src == OIF_LANG_C) {
                 in_args->arg_values[i] = &user_data->c;
             }
@@ -150,7 +150,9 @@ call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *ou
                 in_args->arg_values[i] = &user_data->py;
             }
             else {
-                fprintf(stderr, "[dispatch_c] Cannot handle OIFUserData because of the unsupported language.\n");
+                fprintf(stderr,
+                        "[dispatch_c] Cannot handle OIFUserData because of the unsupported "
+                        "language.\n");
                 goto cleanup;
             }
         }

--- a/oif_impl/c/dispatch_c.c
+++ b/oif_impl/c/dispatch_c.c
@@ -139,8 +139,13 @@ call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *ou
         else if (in_args->arg_types[i] == OIF_ARRAY_F64) {
             arg_types[i] = &ffi_type_pointer;
         }
+        else if (in_args->arg_types[i] == OIF_CALLBACK) {
+            arg_types[i] = &ffi_type_pointer;
+            // We need to take a pointer to a pointer according to the FFI
+            // convention, hence the & operator.
+            in_args->arg_values[i] = &((OIFCallback *)in_args->arg_values[i])->fn_p_c;
+        }
         else if (in_args->arg_types[i] == OIF_USER_DATA) {
-            arg_types[i] = NULL;
             arg_types[i] = &ffi_type_pointer;
             OIFUserData *user_data = (OIFUserData *)in_args->arg_values[i];
             if (user_data->src == OIF_LANG_C) {
@@ -155,12 +160,6 @@ call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *ou
                         "language.\n");
                 goto cleanup;
             }
-        }
-        else if (in_args->arg_types[i] == OIF_CALLBACK) {
-            arg_types[i] = &ffi_type_pointer;
-            // We need to take a pointer to a pointer according to the FFI
-            // convention, hence the & operator.
-            in_args->arg_values[i] = &((OIFCallback *)in_args->arg_values[i])->fn_p_c;
         }
         else {
             fflush(stdout);

--- a/oif_impl/c/dispatch_c.c
+++ b/oif_impl/c/dispatch_c.c
@@ -100,6 +100,9 @@ call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *ou
         else if (in_args->arg_types[i] == OIF_ARRAY_F64) {
             arg_types[i] = &ffi_type_pointer;
         }
+        else if (in_args->arg_types[i] == OIF_VOID_P) {
+            arg_types[i] = &ffi_type_pointer;
+        }
         else if (in_args->arg_types[i] == OIF_CALLBACK) {
             arg_types[i] = &ffi_type_pointer;
             // We need to take a pointer to a pointer according to the FFI

--- a/oif_impl/c/include/oif_impl/ivp.h
+++ b/oif_impl/c/include/oif_impl/ivp.h
@@ -31,4 +31,3 @@ oif_ivp_set_user_data(void *user_data);
  */
 int
 oif_ivp_integrate(double t, OIFArrayF64 *y);
-

--- a/oif_impl/c/include/oif_impl/ivp.h
+++ b/oif_impl/c/include/oif_impl/ivp.h
@@ -5,7 +5,7 @@
 /**
  * Signature of the right-hand side function f for the system of ODEs.
  */
-typedef int (*oif_ivp_rhs_fn_t)(double t, OIFArrayF64 *y, OIFArrayF64 *ydot);
+typedef int (*oif_ivp_rhs_fn_t)(double t, OIFArrayF64 *y, OIFArrayF64 *ydot, void *user_data);
 
 /**
  * Set right hand side of the system of ordinary differential equations.
@@ -18,6 +18,13 @@ oif_ivp_set_rhs_fn(oif_ivp_rhs_fn_t rhs);
  */
 int
 oif_ivp_set_initial_value(OIFArrayF64 *y0, double t0);
+
+/**
+ * Set user data that can be used to pass additional information
+ * to the right-hand side function.
+ */
+int
+oif_ivp_set_user_data(void *user_data);
 
 /**
  * Integrate to time `t` and write the solution to `y`.

--- a/oif_impl/c/include/oif_impl/ivp.h
+++ b/oif_impl/c/include/oif_impl/ivp.h
@@ -31,3 +31,4 @@ oif_ivp_set_user_data(void *user_data);
  */
 int
 oif_ivp_integrate(double t, OIFArrayF64 *y);
+

--- a/oif_impl/c/include/oif_impl/qeq.h
+++ b/oif_impl/c/include/oif_impl/qeq.h
@@ -16,4 +16,3 @@
 int
 solve_qeq(double a, double b, double c, OIFArrayF64 *roots);
 #endif
-

--- a/oif_impl/c/include/oif_impl/qeq.h
+++ b/oif_impl/c/include/oif_impl/qeq.h
@@ -1,10 +1,6 @@
 #ifndef OIF_IMPL_QEQ_H_
 #define OIF_IMPL_QEQ_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <oif/api.h>
 
 /**
@@ -21,6 +17,3 @@ int
 solve_qeq(double a, double b, double c, OIFArrayF64 *roots);
 #endif
 
-#ifdef __cplusplus
-}
-#endif

--- a/oif_impl/c/include/oif_impl/qeq.h
+++ b/oif_impl/c/include/oif_impl/qeq.h
@@ -1,5 +1,9 @@
-#ifndef _OIF_IMPL_QEQ_H_
-#define _OIF_IMPL_QEQ_H_
+#ifndef OIF_IMPL_QEQ_H_
+#define OIF_IMPL_QEQ_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <oif/api.h>
 
@@ -15,4 +19,8 @@
  */
 int
 solve_qeq(double a, double b, double c, OIFArrayF64 *roots);
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/oif_impl/impl/ivp/scipy_ode_dopri5/dopri5.py
+++ b/oif_impl/impl/ivp/scipy_ode_dopri5/dopri5.py
@@ -44,6 +44,8 @@ class Dopri5(IVPInterface):
         return 0
 
     def set_tolerances(self, rtol, atol):
+        if self.s is None:
+            raise RuntimeError("`set_rhs_fn` must be called before `set_tolerances`")
         self.s.set_integrator("dopri5", rtol=rtol, atol=atol, nsteps=1000)
         if hasattr(self, "y0"):
             self.s.set_initial_value(self.y0, self.t0)

--- a/oif_impl/impl/ivp/scipy_ode_dopri5/dopri5.py
+++ b/oif_impl/impl/ivp/scipy_ode_dopri5/dopri5.py
@@ -1,10 +1,11 @@
 import numpy as np
+from oif.impl.ivp import IVPInterface
 from scipy import integrate
 
 _prefix = "scipy_ode_dopri5"
 
 
-class Dopri5:
+class Dopri5(IVPInterface):
     def __init__(self):
         self.rhs = None  # Right-hand side function.
         self.N = 0  # Problem dimension.
@@ -35,11 +36,24 @@ class Dopri5:
         )
         self.s.set_initial_value(self.y0, self.t0)
 
+        if hasattr(self, "user_data"):
+            self.s.set_f_params(self.user_data)
+            self.s.set_jac_params(self.user_data)
+
         return 0
 
     def set_tolerances(self, rtol, atol):
         self.s.set_integrator("dopri5", rtol=rtol, atol=atol, nsteps=1000)
-        self.s.set_initial_value(self.y0, self.t0)
+        if hasattr(self, "y0"):
+            self.s.set_initial_value(self.y0, self.t0)
+        return 0
+
+    def set_user_data(self, user_data):
+        if self.s is not None:
+            self.s.set_f_params(user_data)
+            self.s.set_jac_params(user_data)
+        else:
+            self.user_data = user_data
 
     def integrate(self, t, y):
         y[:] = self.s.integrate(t)

--- a/oif_impl/impl/ivp/scipy_ode_dopri5/dopri5.py
+++ b/oif_impl/impl/ivp/scipy_ode_dopri5/dopri5.py
@@ -10,6 +10,7 @@ class Dopri5(IVPInterface):
         self.rhs = None  # Right-hand side function.
         self.N = 0  # Problem dimension.
         self.s = None
+        self.user_data = None
 
     def set_initial_value(self, y0: np.ndarray, t0: float):
         _p = f"[{_prefix}::set_initial_value]"
@@ -36,9 +37,9 @@ class Dopri5(IVPInterface):
         )
         self.s.set_initial_value(self.y0, self.t0)
 
-        if hasattr(self, "user_data"):
-            self.s.set_f_params(self.user_data)
-            self.s.set_jac_params(self.user_data)
+        # if hasattr(self, "user_data"):
+        #     self.s.set_f_params(self.user_data)
+        #     self.s.set_jac_params(self.user_data)
 
         return 0
 
@@ -49,11 +50,12 @@ class Dopri5(IVPInterface):
         return 0
 
     def set_user_data(self, user_data):
-        if self.s is not None:
-            self.s.set_f_params(user_data)
-            self.s.set_jac_params(user_data)
-        else:
-            self.user_data = user_data
+        # if self.s is not None:
+        #     self.s.set_f_params(user_data)
+        #     self.s.set_jac_params(user_data)
+        # else:
+        #     self.user_data = user_data
+        self.user_data = user_data
 
     def integrate(self, t, y):
         y[:] = self.s.integrate(t)
@@ -62,5 +64,5 @@ class Dopri5(IVPInterface):
 
     def _rhs_fn_wrapper(self, t, y):
         """Callback that satisfies scipy.ode.dopri5 expectations."""
-        self.rhs(t, y, self.ydot)
+        self.rhs(t, y, self.ydot, self.user_data)
         return self.ydot

--- a/oif_impl/impl/ivp/sundials_cvode/sundials_cvode.c
+++ b/oif_impl/impl/ivp/sundials_cvode/sundials_cvode.c
@@ -25,7 +25,7 @@
 const char *prefix = "[ivp::sundials_cvode]";
 
 // Signature for the right-hand side that is provided by the `IVP` interface
-// of the OpenInterFaces.
+// of the Open Interfaces.
 static oif_ivp_rhs_fn_t OIF_RHS_FN;
 
 // Signature for the right-hand side function that CVode expects.
@@ -164,7 +164,7 @@ set_initial_value(OIFArrayF64 *y0_in, double t0_in)
     // 14. Attach nonlinear solver module (optional)
     status = CVodeSetNonlinearSolver(cvode_mem, NLS);
     if (status != CV_SUCCESS) {
-        fprintf(stderr, "%s CVodeSetNonlinearSolver failed with code %d", prefix, status);
+        fprintf(stderr, "%s CVodeSetNonlinearSolver failed with code %d\n", prefix, status);
         return 8;
     }
     // 15. Set nonlinear solver optional inputs (optional)
@@ -172,6 +172,21 @@ set_initial_value(OIFArrayF64 *y0_in, double t0_in)
 
     N_VDestroy_Serial(y0);
 
+    return 0;
+}
+
+int
+set_user_data(void *user_data)
+{
+    int status = CVodeSetUserData(cvode_mem, user_data);
+    if (status == CV_MEM_NULL) {
+        fprintf(
+            stderr,
+            "%s Could not set user data as "
+            "CVODE memory block is not yet initialized\n", prefix);
+        return 1;
+    }
+    assert(status == CV_SUCCESS);
     return 0;
 }
 
@@ -248,7 +263,7 @@ cvode_rhs(sunrealtype t, N_Vector y, N_Vector ydot, void *user_data)
                             .dimensions = (intptr_t[]){N_VGetLength(ydot)},
                             .data = N_VGetArrayPointer(ydot)};
 
-    int result = OIF_RHS_FN(t, &oif_y, &oif_ydot);
+    int result = OIF_RHS_FN(t, &oif_y, &oif_ydot, user_data);
 
     return result;
 }

--- a/oif_impl/impl/ivp/sundials_cvode/sundials_cvode.c
+++ b/oif_impl/impl/ivp/sundials_cvode/sundials_cvode.c
@@ -180,10 +180,10 @@ set_user_data(void *user_data)
 {
     int status = CVodeSetUserData(cvode_mem, user_data);
     if (status == CV_MEM_NULL) {
-        fprintf(
-            stderr,
-            "%s Could not set user data as "
-            "CVODE memory block is not yet initialized\n", prefix);
+        fprintf(stderr,
+                "%s Could not set user data as "
+                "CVODE memory block is not yet initialized\n",
+                prefix);
         return 1;
     }
     assert(status == CV_SUCCESS);

--- a/oif_impl/python/_callback.c
+++ b/oif_impl/python/_callback.c
@@ -64,7 +64,7 @@ PythonWrapperForCCallback_init(PythonWrapperForCCallbackObject *self, PyObject *
 
     self->fn_p = PyCapsule_GetPointer(capsule, "123");
 
-    assert(nargs==4);
+    assert(nargs == 4);
     nargs = 4;
     self->nargs = nargs;
 

--- a/oif_impl/python/_callback.c
+++ b/oif_impl/python/_callback.c
@@ -179,12 +179,6 @@ PythonWrapperForCCallback_call(PyObject *myself, PyObject *args, PyObject *Py_UN
     PythonWrapperForCCallbackObject *self = (PythonWrapperForCCallbackObject *)myself;
     PyObject *retval = NULL;
 
-    // We need to initialize PyArray_API (table of function pointers)
-    // in every translation unit (separate .c file).
-    // See the details in the accepted solution here:
-    // https://stackoverflow.com/q/47026900/1095202
-    import_array();
-
     /* if (!PyArg_ParseTuple(args, "O!", &PyTuple_Type, &py_args)) { */
     /*     fprintf(stderr, "[_callback] Could not parse function arguments\n");
      */
@@ -343,6 +337,12 @@ PyMODINIT_FUNC
 PyInit__callback(void)
 {
     PyObject *m;
+
+    // We need to initialize PyArray_API (table of function pointers)
+    // in every translation unit (separate .c file).
+    // See the details in the accepted solution here:
+    // https://stackoverflow.com/q/47026900/1095202
+    import_array();
 
     if (PyType_Ready(&PythonWrapperForCCallbackType) < 0) {
         fprintf(stderr, "[_callback] Type is not ready\n");

--- a/oif_impl/python/dispatch_python.c
+++ b/oif_impl/python/dispatch_python.c
@@ -75,6 +75,8 @@ convert_oif_callback(OIFCallback *p)
 ImplInfo *
 load_impl(const char *impl_details, size_t version_major, size_t version_minor)
 {
+    (void) version_major;
+    (void) version_minor;
     if (Py_IsInitialized()) {
         fprintf(stderr, "[%s] Backend is already initialized\n", prefix);
     }
@@ -195,11 +197,11 @@ call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *ou
     pFunc = PyObject_GetAttrString(impl->pInstance, method);
 
     if (pFunc && PyCallable_Check(pFunc)) {
-        int num_args = in_args->num_args + out_args->num_args;
+        size_t num_args = in_args->num_args + out_args->num_args;
         PyObject *pArgs = PyTuple_New(num_args);
 
         // Convert input arguments.
-        for (int i = 0; i < in_args->num_args; ++i) {
+        for (size_t i = 0; i < in_args->num_args; ++i) {
             if (in_args->arg_types[i] == OIF_FLOAT64) {
                 pValue = PyFloat_FromDouble(*(double *)in_args->arg_values[i]);
             }
@@ -243,7 +245,7 @@ call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *ou
                 }
                 if (!PyCallable_Check(pValue)) {
                     fprintf(stderr,
-                            "[%s] Input argument #%d "
+                            "[%s] Input argument #%zu "
                             "has type OIF_CALLBACK "
                             "but it is actually is not callable\n",
                             prefix, i);
@@ -256,7 +258,7 @@ call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *ou
                 Py_DECREF(pArgs);
                 Py_DECREF(pFunc);
                 fprintf(stderr,
-                        "[%s] Cannot convert input argument #%d with "
+                        "[%s] Cannot convert input argument #%zu with "
                         "provided type id %d\n",
                         prefix, i, in_args->arg_types[i]);
                 return 1;
@@ -264,7 +266,7 @@ call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *ou
             PyTuple_SetItem(pArgs, i, pValue);
         }
         // Convert output arguments.
-        for (int i = 0; i < out_args->num_args; ++i) {
+        for (size_t i = 0; i < out_args->num_args; ++i) {
             if (out_args->arg_types[i] == OIF_INT) {
                 pValue = PyLong_FromLong(*(int *)out_args->arg_values[i]);
             }
@@ -282,7 +284,7 @@ call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *ou
             if (!pValue) {
                 Py_DECREF(pArgs);
                 Py_DECREF(pFunc);
-                fprintf(stderr, "[%s] Cannot convert out_arg %d of type %d\n", prefix, i,
+                fprintf(stderr, "[%s] Cannot convert out_arg %zu of type %d\n", prefix, i,
                         out_args->arg_types[i]);
                 return 1;
             }

--- a/oif_impl/python/oif/impl/ivp.py
+++ b/oif_impl/python/oif/impl/ivp.py
@@ -1,0 +1,26 @@
+import abc
+from typing import Callable, Union
+
+import numpy as np
+
+
+class IVPInterface(abc.ABC):
+    @abc.abstractmethod
+    def set_initial_value(self, y0: np.ndarray, t0: float) -> Union[int, None]:
+        """Set initial value y(t0) = y0."""
+
+    @abc.abstractmethod
+    def set_rhs_fn(self, rhs: Callable) -> Union[int, None]:
+        """Specify right-hand side function f."""
+
+    @abc.abstractmethod
+    def set_tolerances(self, rtol: float, atol: float) -> Union[int, None]:
+        """Specify relative and absolute tolerances, respectively."""
+
+    @abc.abstractmethod
+    def integrate(self, t: float, y: np.ndarray) -> Union[int, None]:
+        """Integrate to time `t` and write solution to `y`."""
+
+    @abc.abstractmethod
+    def set_user_data(self, user_data: object) -> Union[int, None]:
+        """Specify additional data that will be used for right-hand side function."""

--- a/test_cvode.py
+++ b/test_cvode.py
@@ -1,0 +1,38 @@
+import numpy as np
+from oif.interfaces.ivp import IVP
+from scikits.odes.ode import ode
+
+
+def rhs(t, y, ydot):
+    ydot[:] = -y
+
+
+s_oif = IVP("sundials_cvode")
+s = ode(
+    "cvode",
+    rhs,
+    old_api=False,
+    lmm_type="ADAMS",
+    nonlinsolver="fixedpoint",
+    rtol=1e-15,
+    atol=1e-15,
+)
+
+y0 = np.array([1.0])
+t0 = 0.0
+
+s_oif.set_initial_value(y0, t0)
+s.init_step(t0, y0)
+s_oif.set_rhs_fn(rhs)
+
+for t in [0.1, 0.2]:
+    s_oif.integrate(t)
+    output = s.step(t)
+    print("s_oif.y: ", s_oif.y)
+    print("sundials.y: ", output.values.y)
+
+s_oif.print_stats()
+# print(s.get_info())
+print("=========================================================")
+print()
+s.print_stats()

--- a/tests/lang_c/test_ivp.cpp
+++ b/tests/lang_c/test_ivp.cpp
@@ -1,4 +1,3 @@
-#include "gtest/gtest.h"
 #include <cmath>
 #include <cstdio>
 
@@ -12,12 +11,38 @@ extern "C" {
 
 const double EPS = 0.9;
 
-class ScalarExpDecayProblem {
+class ODEProblem {
+public:
+    int N;
+    double *y0;
+
+    ODEProblem(int N) : N(N) {
+        y0 = new double[N];
+    }
+
+    ~ODEProblem() {
+        delete[] y0;
+    }
+
+    static int rhs_wrapper(double t, OIFArrayF64 *y, OIFArrayF64 *ydot, void *user_data) {
+        ODEProblem *problem = reinterpret_cast<ODEProblem*>(user_data);
+        problem->rhs(t, y, ydot, NULL);
+        return 0;
+    }
+
+    virtual int rhs(double t, OIFArrayF64 *y, OIFArrayF64 *ydot, void *user_data) = 0;
+
+    virtual void verify(double t, OIFArrayF64 *y) = 0;
+};
+
+class ScalarExpDecayProblem : public ODEProblem {
    public:
-    static constexpr int N = 1;
-    static constexpr double y0[] = {1.0};
-    static int
-    rhs(double t, OIFArrayF64 *y, OIFArrayF64 *rhs_out)
+    ScalarExpDecayProblem() : ODEProblem(1) {
+        y0[0] = 1.0;
+    }
+
+    int
+    rhs(double /* t */, OIFArrayF64 *y, OIFArrayF64 *rhs_out, void */* user_data */) override
     {
         int size = y->dimensions[0];
         for (int i = 0; i < size; ++i) {
@@ -25,42 +50,51 @@ class ScalarExpDecayProblem {
         }
         return 0;
     }
-    static void
-    verify(double t, OIFArrayF64 *y)
+
+    void
+    verify(double t, OIFArrayF64 *y) override
     {
         EXPECT_NEAR(y->data[0], exp(-t), 1e-14);
     }
 };
 
-class LinearOscillatorProblem {
-   public:
-    static constexpr int N = 2;
-    static constexpr double y0[2] = {1.0, 0.5};
-    static constexpr double omega = M_PI;
-    static int
-    rhs(double t, OIFArrayF64 *y, OIFArrayF64 *rhs_out)
+class LinearOscillatorProblem : public ODEProblem {
+    public:
+    LinearOscillatorProblem() : ODEProblem(2) {
+        y0[0] = 1.0;
+        y0[1] = 0.5;
+    }
+
+    int
+    rhs(double /* t */, OIFArrayF64 *y, OIFArrayF64 *rhs_out, void */* user_data */) override
     {
         rhs_out->data[0] = y->data[1];
         rhs_out->data[1] = -omega * omega * y->data[0];
         return 0;
     }
-    static void
-    verify(double t, OIFArrayF64 *y)
+    void
+    verify(double t, OIFArrayF64 *y) override
     {
         double y_exact_0 = y0[0] * cos(omega * t) + y0[1] * sin(omega * t) / omega;
         EXPECT_NEAR(y->data[0], y_exact_0, 1e-12);
         double y_exact_1 = -y0[0] * omega * sin(omega * t) + y0[1] * cos(omega * t);
         EXPECT_NEAR(y->data[1], y_exact_1, 1e-12);
     }
+    private:
+    double omega = M_PI;
 };
 
-class OrbitEquationsProblem {
-   public:
-    static constexpr int N = 4;
-    static constexpr double eps = 0.9L;
-    static constexpr double y0[4] = {1 - eps, 0.0, 0.0, constexpr_sqrt((1 + eps) / (1 - eps))};
-    static int
-    rhs(double t, OIFArrayF64 *y, OIFArrayF64 *rhs_out)
+class OrbitEquationsProblem : public ODEProblem {
+    public:
+    OrbitEquationsProblem() : ODEProblem(4) {
+        y0[0] = 1 - eps;
+        y0[1] = 0.0;
+        y0[2] = 0.0;
+        y0[3] = sqrt((1 + eps) / (1 - eps));
+    }
+
+    int
+    rhs(double /* t */, OIFArrayF64 *y, OIFArrayF64 *rhs_out, void */* user_data */) override
     {
         double r = sqrt(y->data[0] * y->data[0] + y->data[1] * y->data[1]);
         rhs_out->data[0] = y->data[2];
@@ -70,93 +104,48 @@ class OrbitEquationsProblem {
 
         return 0;
     }
-    static void
-    verify(double t, OIFArrayF64 *y)
+
+    void
+    verify(double t, OIFArrayF64 *y) override
     {
-        double u = fsolve([t](double u) { return u - eps * sin(u) - t; },
-                          [](double u) { return 1 - eps * cos(u); });
+        double u = fsolve([&, t](double u) { return u - eps * sin(u) - t; },
+                          [&](double u) { return 1 - eps * cos(u); });
         EXPECT_NEAR(y->data[0], cos(u) - eps, 1e-10);
         EXPECT_NEAR(y->data[1], sqrt(1 - pow(eps, 2)) * sin(u), 1e-10);
         EXPECT_NEAR(y->data[2], -sin(u) / (1 - eps * cos(u)), 1e-10);
         EXPECT_NEAR(y->data[3], sqrt(1 - pow(eps, 2)) * cos(u) / (1 - eps * cos(u)), 1e-10);
     }
+   private:
+   double eps = 0.9L;
 };
 
-struct IvpImplementationsFixture : public testing::TestWithParam<const char *> {};
+struct IvpImplementationsFixture : public testing::TestWithParam<std::tuple<const char *, ODEProblem *>> {};
 
 TEST_P(IvpImplementationsFixture, ScalarExpDecayTestCase)
 {
+    const char *impl = std::get<0>(GetParam());
+    ODEProblem *problem = std::get<1>(GetParam());
     double t0 = 0.0;
     intptr_t dims[] = {
-        ScalarExpDecayProblem::N,
+        problem->N,
     };
-    OIFArrayF64 *y0 = oif_init_array_f64_from_data(1, dims, ScalarExpDecayProblem::y0);
+    OIFArrayF64 *y0 = oif_init_array_f64_from_data(1, dims, problem->y0);
     OIFArrayF64 *y = oif_create_array_f64(1, dims);
-    ImplHandle implh = oif_init_impl("ivp", GetParam(), 1, 0);
+    ImplHandle implh = oif_init_impl("ivp", impl, 1, 0);
 
     int status;
     status = oif_ivp_set_initial_value(implh, y0, t0);
     EXPECT_EQ(status, 0);
-    status = oif_ivp_set_rhs_fn(implh, ScalarExpDecayProblem::rhs);
+    status = oif_ivp_set_user_data(implh, &problem);
+    EXPECT_EQ(status, 0);
+    status = oif_ivp_set_rhs_fn(implh, ODEProblem::rhs_wrapper);
     EXPECT_EQ(status, 0);
 
     auto t_span = {0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 2.0};
     for (auto t : t_span) {
         status = oif_ivp_integrate(implh, t, y);
         EXPECT_EQ(status, 0);
-        ScalarExpDecayProblem::verify(t, y);
-    }
-
-    oif_free_array_f64(y0);
-    oif_free_array_f64(y);
-}
-
-TEST_P(IvpImplementationsFixture, LinearOscillatorTestCase)
-{
-    double t0 = 0.0;
-    intptr_t dims[] = {
-        LinearOscillatorProblem::N,
-    };
-    OIFArrayF64 *y0 = oif_init_array_f64_from_data(1, dims, LinearOscillatorProblem::y0);
-    OIFArrayF64 *y = oif_create_array_f64(1, dims);
-    ImplHandle implh = oif_init_impl("ivp", GetParam(), 1, 0);
-
-    int status;
-    status = oif_ivp_set_initial_value(implh, y0, t0);
-    EXPECT_EQ(status, 0);
-    status = oif_ivp_set_rhs_fn(implh, LinearOscillatorProblem::rhs);
-    EXPECT_EQ(status, 0);
-
-    auto t_span = {0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 2.0};
-    for (auto t : t_span) {
-        status = oif_ivp_integrate(implh, t, y);
-        LinearOscillatorProblem::verify(t, y);
-    }
-
-    oif_free_array_f64(y0);
-    oif_free_array_f64(y);
-}
-
-TEST_P(IvpImplementationsFixture, OrbitEquationsProblemTestCase)
-{
-    double t0 = 0.0;
-    intptr_t dims[] = {
-        OrbitEquationsProblem::N,
-    };
-    OIFArrayF64 *y0 = oif_init_array_f64_from_data(1, dims, OrbitEquationsProblem::y0);
-    OIFArrayF64 *y = oif_create_array_f64(1, dims);
-    ImplHandle implh = oif_init_impl("ivp", GetParam(), 1, 0);
-
-    int status;
-    status = oif_ivp_set_initial_value(implh, y0, t0);
-    EXPECT_EQ(status, 0);
-    status = oif_ivp_set_rhs_fn(implh, OrbitEquationsProblem::rhs);
-    EXPECT_EQ(status, 0);
-
-    auto t_span = {0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 2.0};
-    for (auto t : t_span) {
-        status = oif_ivp_integrate(implh, t, y);
-        OrbitEquationsProblem::verify(t, y);
+        problem->verify(t, y);
     }
 
     oif_free_array_f64(y0);
@@ -164,4 +153,6 @@ TEST_P(IvpImplementationsFixture, OrbitEquationsProblemTestCase)
 }
 
 INSTANTIATE_TEST_SUITE_P(IvpImplementationsTests, IvpImplementationsFixture,
-                         testing::Values("scipy_ode_dopri5", "sundials_cvode"));
+                         testing::Combine(
+                             testing::Values("sundials_cvode"),
+                             testing::Values(new ScalarExpDecayProblem(), new LinearOscillatorProblem(), new OrbitEquationsProblem())));

--- a/tests/lang_c/test_ivp.cpp
+++ b/tests/lang_c/test_ivp.cpp
@@ -4,10 +4,8 @@
 #include "testutils.h"
 #include <gtest/gtest.h>
 
-extern "C" {
 #include "oif/c_bindings.h"
 #include "oif/interfaces/ivp.h"
-}
 
 const double EPS = 0.9;
 

--- a/tests/lang_c/test_ivp.cpp
+++ b/tests/lang_c/test_ivp.cpp
@@ -155,19 +155,20 @@ TEST_P(IvpImplementationsFixture, ScalarExpDecayTestCase)
     OIFArrayF64 *y0 = oif_init_array_f64_from_data(1, dims, problem->y0);
     OIFArrayF64 *y = oif_create_array_f64(1, dims);
     ImplHandle implh = oif_init_impl("ivp", impl, 1, 0);
+    ASSERT_GT(implh, 0);
 
     int status;
     status = oif_ivp_set_initial_value(implh, y0, t0);
-    EXPECT_EQ(status, 0);
+    ASSERT_EQ(status, 0);
     status = oif_ivp_set_user_data(implh, problem);
-    EXPECT_EQ(status, 0);
+    ASSERT_EQ(status, 0);
     status = oif_ivp_set_rhs_fn(implh, ODEProblem::rhs_wrapper);
-    EXPECT_EQ(status, 0);
+    ASSERT_EQ(status, 0);
 
     auto t_span = {0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 2.0};
     for (auto t : t_span) {
         status = oif_ivp_integrate(implh, t, y);
-        EXPECT_EQ(status, 0);
+        ASSERT_EQ(status, 0);
         problem->verify(t, y);
     }
 
@@ -177,5 +178,5 @@ TEST_P(IvpImplementationsFixture, ScalarExpDecayTestCase)
 
 INSTANTIATE_TEST_SUITE_P(IvpImplementationsTests, IvpImplementationsFixture,
                          testing::Combine(
-                             testing::Values("sundials_cvode"),
+                             testing::Values("sundials_cvode", "scipy_ode_dopri5"),
                              testing::Values(new ScalarExpDecayProblem(), new LinearOscillatorProblem(), new OrbitEquationsProblem())));

--- a/tests/lang_c/test_ivp.cpp
+++ b/tests/lang_c/test_ivp.cpp
@@ -174,6 +174,7 @@ TEST_P(IvpImplementationsFixture, ScalarExpDecayTestCase)
 
     oif_free_array_f64(y0);
     oif_free_array_f64(y);
+    oif_unload_impl(implh);
 }
 
 INSTANTIATE_TEST_SUITE_P(IvpImplementationsTests, IvpImplementationsFixture,

--- a/tests/lang_c/test_linsolve.cpp
+++ b/tests/lang_c/test_linsolve.cpp
@@ -1,9 +1,7 @@
 #include <gtest/gtest.h>
 
-extern "C" {
 #include "oif/c_bindings.h"
 #include "oif/interfaces/linsolve.h"
-}
 
 class LinearSolverFixture : public ::testing::TestWithParam<const char *> {};
 

--- a/tests/lang_c/test_linsolve.cpp
+++ b/tests/lang_c/test_linsolve.cpp
@@ -20,11 +20,11 @@ TEST_P(LinearSolverFixture, TestCase1)
     int status = oif_solve_linear_system(implh, A, b, roots);
     EXPECT_EQ(status, 0);
 
-    int M = A->dimensions[0];
-    int N = A->dimensions[1];
-    for (size_t i = 0; i < M; ++i) {
+    intptr_t M = A->dimensions[0];
+    intptr_t N = A->dimensions[1];
+    for (int i = 0; i < M; ++i) {
         float scalar_product = 0.0;
-        for (size_t j = 0; j < N; ++j) {
+        for (int j = 0; j < N; ++j) {
             scalar_product += A->data[i * N + j] * roots->data[j];
         }
         EXPECT_FLOAT_EQ(scalar_product, b->data[i]);

--- a/tests/lang_c/test_qeq.cpp
+++ b/tests/lang_c/test_qeq.cpp
@@ -12,11 +12,13 @@ TEST(QeqPyQeqSolverTestSuite, LinearCase)
     ImplHandle implh = oif_init_impl("qeq", "py_qeq_solver", 1, 0);
 
     int status = oif_solve_qeq(implh, 0.0, 2.0, -1.0, roots);
+    ASSERT_EQ(status, 0);
 
     EXPECT_EQ(roots->data[0], 0.5);
     EXPECT_EQ(roots->data[1], 0.5);
 
     oif_free_array_f64(roots);
+    oif_unload_impl(implh);
 }
 
 TEST(QeqPyQeqSolverTestSuite, TwoRoots)
@@ -28,10 +30,12 @@ TEST(QeqPyQeqSolverTestSuite, TwoRoots)
     ImplHandle implh = oif_init_impl("qeq", "py_qeq_solver", 1, 0);
 
     int status = oif_solve_qeq(implh, 1.0, 2.0, 1.0, roots);
+    ASSERT_EQ(status, 0);
 
     EXPECT_EQ(roots->data[0], -1.0);
     EXPECT_EQ(roots->data[1], -1.0);
     oif_free_array_f64(roots);
+    oif_unload_impl(implh);
 }
 
 TEST(QeqPyQeqSolverTestSuite, TwoDistinctRoots)
@@ -43,10 +47,12 @@ TEST(QeqPyQeqSolverTestSuite, TwoDistinctRoots)
     ImplHandle implh = oif_init_impl("qeq", "py_qeq_solver", 1, 0);
 
     int status = oif_solve_qeq(implh, 1, 5, -14, roots);
+    ASSERT_EQ(status, 0);
 
     EXPECT_EQ(roots->data[0], -7);
     EXPECT_EQ(roots->data[1], +2);
     oif_free_array_f64(roots);
+    oif_unload_impl(implh);
 }
 
 TEST(QeqCQeqSolverTestSuite, LinearCase)
@@ -58,10 +64,12 @@ TEST(QeqCQeqSolverTestSuite, LinearCase)
     ImplHandle implh = oif_init_impl("qeq", "c_qeq_solver", 1, 0);
 
     int status = oif_solve_qeq(implh, 0.0, 2.0, -1.0, roots);
+    ASSERT_EQ(status, 0);
 
     EXPECT_EQ(roots->data[0], 0.5);
     EXPECT_EQ(roots->data[1], 0.5);
     oif_free_array_f64(roots);
+    oif_unload_impl(implh);
 }
 
 TEST(QeqCQeqSolverTestSuite, TwoRoots)
@@ -73,10 +81,12 @@ TEST(QeqCQeqSolverTestSuite, TwoRoots)
     ImplHandle implh = oif_init_impl("qeq", "c_qeq_solver", 1, 0);
 
     int status = oif_solve_qeq(implh, 1.0, 2.0, 1.0, roots);
+    ASSERT_EQ(status, 0);
 
     EXPECT_EQ(roots->data[0], -1.0);
     EXPECT_EQ(roots->data[1], -1.0);
     oif_free_array_f64(roots);
+    oif_unload_impl(implh);
 }
 
 TEST(QeqCQeqSolverTestSuite, TwoDistinctRoots)
@@ -88,10 +98,12 @@ TEST(QeqCQeqSolverTestSuite, TwoDistinctRoots)
     ImplHandle implh = oif_init_impl("qeq", "c_qeq_solver", 1, 0);
 
     int status = oif_solve_qeq(implh, 1, 5, -14, roots);
+    ASSERT_EQ(status, 0);
 
     EXPECT_EQ(roots->data[0], -7);
     EXPECT_EQ(roots->data[1], +2);
     oif_free_array_f64(roots);
+    oif_unload_impl(implh);
 }
 
 TEST(QeqCQeqSolverTestSuite, ExtremeRoots)
@@ -103,8 +115,10 @@ TEST(QeqCQeqSolverTestSuite, ExtremeRoots)
     ImplHandle implh = oif_init_impl("qeq", "c_qeq_solver", 1, 0);
 
     int status = oif_solve_qeq(implh, 1, -20'000, 1.0, roots);
+    ASSERT_EQ(status, 0);
 
     EXPECT_EQ(roots->data[0], 19999.999949999998);
     EXPECT_EQ(roots->data[1], 5.000000012500001e-05);
     oif_free_array_f64(roots);
+    oif_unload_impl(implh);
 }

--- a/tests/lang_c/test_qeq.cpp
+++ b/tests/lang_c/test_qeq.cpp
@@ -1,9 +1,7 @@
 #include <gtest/gtest.h>
 
-extern "C" {
 #include "oif/c_bindings.h"
 #include "oif/interfaces/qeq.h"
-}
 
 TEST(QeqPyQeqSolverTestSuite, LinearCase)
 {


### PR DESCRIPTION
This PR has started actually only with the unit tests for new `set_tolerances` method in the `IVP` interface. However, during its implementation, I have restructured heavily the C tests that are written in Google Test in C++. Because of the mismatch between C callbacks and class methods in C++, I have started to work on the additional argument for the right-hand-side callbacks, to be able to use them for injection of C++ objects.

Hence, this PR turned out to be bigger:
- Now right-hand side functions in the `IVP` interface have signature `int rhs_fn(double t, OIFArrayF64 *y, OIFArrayF64 *y, void *user_data)` (in terms of C types)
- Tests in `test_ivp.cpp` and `test_ivp.py` were updated for this use case and also new tests for `set_tolerances` were added.